### PR TITLE
feat: project 08 - backtesting

### DIFF
--- a/02 - AI Algorithms in Trading/Project 08 - Backtesting/Project 08 - Backtesting/project_8_starter.ipynb
+++ b/02 - AI Algorithms in Trading/Project 08 - Backtesting/Project 08 - Backtesting/project_8_starter.ipynb
@@ -1,0 +1,1545 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Project 8: Backtesting\n",
+    "\n",
+    "In this project, you will build a fairly realistic backtester that uses the Barra data. The backtester will perform portfolio optimization that includes transaction costs, and you'll implement it with computational efficiency in mind, to allow for a reasonably fast backtest. You'll also use performance attribution to identify the major drivers of your portfolio's profit-and-loss (PnL). You will have the option to modify and customize the backtest as well.\n",
+    "\n",
+    "\n",
+    "## Instructions\n",
+    "\n",
+    "Each problem consists of a function to implement and instructions on how to implement the function.  The parts of the function that need to be implemented are marked with a `# TODO` comment. Your code will be checked for the correct solution when you submit it to Udacity.\n",
+    "\n",
+    "\n",
+    "## Packages\n",
+    "\n",
+    "When you implement the functions, you'll only need to you use the packages you've used in the classroom, like [Pandas](https://pandas.pydata.org/) and [Numpy](http://www.numpy.org/). These packages will be imported for you. We recommend you don't add any import statements, otherwise the grader might not be able to run your code.\n",
+    "\n",
+    "### Install Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: matplotlib==2.1.0 in /opt/conda/lib/python3.6/site-packages (from -r requirements.txt (line 1)) (2.1.0)\n",
+      "Collecting numpy==1.16.1 (from -r requirements.txt (line 2))\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f5/bf/4981bcbee43934f0adb8f764a1e70ab0ee5a448f6505bd04a87a2fda2a8b/numpy-1.16.1-cp36-cp36m-manylinux1_x86_64.whl (17.3MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 17.3MB 2.3MB/s eta 0:00:01 1% |▌                               | 266kB 8.3MB/s eta 0:00:03    35% |███████████▍                    | 6.2MB 24.9MB/s eta 0:00:01    42% |█████████████▊                  | 7.4MB 25.3MB/s eta 0:00:01    82% |██████████████████████████▌     | 14.4MB 23.0MB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting pandas==0.24.1 (from -r requirements.txt (line 3))\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e6/de/a0d3defd8f338eaf53ef716e40ef6d6c277c35d50e09b586e170169cdf0d/pandas-0.24.1-cp36-cp36m-manylinux1_x86_64.whl (10.1MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 10.1MB 5.7MB/s eta 0:00:01   11% |███▊                            | 1.2MB 22.8MB/s eta 0:00:01    35% |███████████▌                    | 3.6MB 25.3MB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting patsy==0.5.1 (from -r requirements.txt (line 4))\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/ea/0c/5f61f1a3d4385d6bf83b83ea495068857ff8dfb89e74824c6e9eb63286d8/patsy-0.5.1-py2.py3-none-any.whl (231kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 235kB 18.9MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting scipy==0.19.1 (from -r requirements.txt (line 5))\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/0e/46/da8d7166102d29695330f7c0b912955498542988542c0d2ae3ea0389c68d/scipy-0.19.1-cp36-cp36m-manylinux1_x86_64.whl (48.2MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 48.2MB 801kB/s eta 0:00:010% |                                | 51kB 11.0MB/s eta 0:00:05    2% |▉                               | 1.2MB 22.7MB/s eta 0:00:03    4% |█▋                              | 2.4MB 23.0MB/s eta 0:00:02    7% |██▍                             | 3.5MB 23.9MB/s eta 0:00:02    9% |███▏                            | 4.7MB 24.3MB/s eta 0:00:02    12% |████                            | 5.9MB 25.2MB/s eta 0:00:02    14% |████▊                           | 7.0MB 23.3MB/s eta 0:00:02    16% |█████▍                          | 8.2MB 24.1MB/s eta 0:00:02    26% |████████▌                       | 12.8MB 24.6MB/s eta 0:00:02    40% |█████████████                   | 19.5MB 22.8MB/s eta 0:00:02    42% |█████████████▋                  | 20.6MB 21.2MB/s eta 0:00:02    44% |██████████████▍                 | 21.6MB 23.3MB/s eta 0:00:02    47% |███████████████                 | 22.7MB 23.4MB/s eta 0:00:02    49% |███████████████▉                | 23.8MB 23.0MB/s eta 0:00:02    58% |██████████████████▊             | 28.2MB 23.4MB/s eta 0:00:01    63% |████████████████████▏           | 30.4MB 22.1MB/s eta 0:00:01    65% |█████████████████████           | 31.8MB 18.1MB/s eta 0:00:01    72% |███████████████████████         | 34.8MB 17.6MB/s eta 0:00:01    74% |███████████████████████▉        | 35.9MB 22.5MB/s eta 0:00:01    75% |████████████████████████▎       | 36.6MB 18.7MB/s eta 0:00:01    81% |██████████████████████████▏     | 39.4MB 20.3MB/s eta 0:00:01    84% |███████████████████████████     | 40.5MB 21.2MB/s eta 0:00:01    85% |███████████████████████████▌    | 41.4MB 17.3MB/s eta 0:00:01    87% |████████████████████████████▏   | 42.4MB 20.4MB/s eta 0:00:01    91% |█████████████████████████████▍  | 44.4MB 20.0MB/s eta 0:00:01    94% |██████████████████████████████▏ | 45.4MB 21.6MB/s eta 0:00:01    98% |███████████████████████████████▌| 47.5MB 19.2MB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting statsmodels==0.9.0 (from -r requirements.txt (line 6))\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/85/d1/69ee7e757f657e7f527cbf500ec2d295396e5bcec873cf4eb68962c41024/statsmodels-0.9.0-cp36-cp36m-manylinux1_x86_64.whl (7.4MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 7.4MB 6.1MB/s eta 0:00:01   2% |▋                               | 153kB 15.7MB/s eta 0:00:01    16% |█████▍                          | 1.2MB 21.8MB/s eta 0:00:01    43% |██████████████                  | 3.2MB 21.6MB/s eta 0:00:01    70% |██████████████████████▌         | 5.2MB 21.5MB/s eta 0:00:01    84% |███████████████████████████▏    | 6.3MB 20.9MB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting tqdm==4.19.5 (from -r requirements.txt (line 7))\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/71/3c/341b4fa23cb3abc335207dba057c790f3bb329f6757e1fcd5d347bcf8308/tqdm-4.19.5-py2.py3-none-any.whl (51kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 61kB 9.0MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: six>=1.10 in /opt/conda/lib/python3.6/site-packages (from matplotlib==2.1.0->-r requirements.txt (line 1)) (1.11.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.0 in /opt/conda/lib/python3.6/site-packages (from matplotlib==2.1.0->-r requirements.txt (line 1)) (2.6.1)\n",
+      "Requirement already satisfied: pytz in /opt/conda/lib/python3.6/site-packages (from matplotlib==2.1.0->-r requirements.txt (line 1)) (2017.3)\n",
+      "Requirement already satisfied: cycler>=0.10 in /opt/conda/lib/python3.6/site-packages/cycler-0.10.0-py3.6.egg (from matplotlib==2.1.0->-r requirements.txt (line 1)) (0.10.0)\n",
+      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /opt/conda/lib/python3.6/site-packages (from matplotlib==2.1.0->-r requirements.txt (line 1)) (2.2.0)\n",
+      "\u001b[31mtensorflow 1.3.0 requires tensorflow-tensorboard<0.2.0,>=0.1.0, which is not installed.\u001b[0m\n",
+      "\u001b[31mmoviepy 0.2.3.2 has requirement tqdm==4.11.2, but you'll have tqdm 4.19.5 which is incompatible.\u001b[0m\n",
+      "Installing collected packages: numpy, pandas, patsy, scipy, statsmodels, tqdm\n",
+      "  Found existing installation: numpy 1.12.1\n",
+      "    Uninstalling numpy-1.12.1:\n",
+      "      Successfully uninstalled numpy-1.12.1\n",
+      "  Found existing installation: pandas 0.23.3\n",
+      "    Uninstalling pandas-0.23.3:\n",
+      "      Successfully uninstalled pandas-0.23.3\n",
+      "  Found existing installation: patsy 0.4.1\n",
+      "    Uninstalling patsy-0.4.1:\n",
+      "      Successfully uninstalled patsy-0.4.1\n",
+      "  Found existing installation: scipy 1.2.1\n",
+      "    Uninstalling scipy-1.2.1:\n",
+      "      Successfully uninstalled scipy-1.2.1\n",
+      "  Found existing installation: statsmodels 0.8.0\n",
+      "    Uninstalling statsmodels-0.8.0:\n",
+      "      Successfully uninstalled statsmodels-0.8.0\n",
+      "  Found existing installation: tqdm 4.11.2\n",
+      "    Uninstalling tqdm-4.11.2:\n",
+      "      Successfully uninstalled tqdm-4.11.2\n",
+      "Successfully installed numpy-1.16.1 pandas-0.24.1 patsy-0.5.1 scipy-0.19.1 statsmodels-0.9.0 tqdm-4.19.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "!{sys.executable} -m pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy\n",
+    "import patsy\n",
+    "import pickle\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import scipy.sparse\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from statistics import median\n",
+    "from scipy.stats import gaussian_kde\n",
+    "from statsmodels.formula.api import ols\n",
+    "from tqdm import tqdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data\n",
+    "\n",
+    "We’ll be using the Barra dataset to get factors that can be used to predict risk. Loading and parsing the raw Barra data can be a very slow process that can significantly slow down your backtesting. For this reason, it's important to pre-process the data beforehand. For your convenience, the Barra data has already been pre-processed for you and saved into pickle files. You will load the Barra data from these pickle files.\n",
+    "\n",
+    "In the code below, we start by loading `2004` factor data from the `pandas-frames.2004.pickle` file. We also load the `2003` and `2004` covariance data from the `covaraince.2003.pickle`  and `covaraince.2004.pickle` files. You are encouraged  to customize the data range for your backtest. For example, we recommend starting with two or three years of factor data. Remember that the covariance data should include all the years that you choose for the factor data,   and also one year earlier. For example, in the code below we are using  `2004` factor data, therefore, we must include `2004` in our covariance data, but also the previous year, `2003`. If you don't remember why must include this previous year, feel free to review the lessons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "barra_dir = '../../data/project_8_barra/'\n",
+    "\n",
+    "data = {}\n",
+    "for year in [2004]:\n",
+    "    fil = barra_dir + \"pandas-frames.\" + str(year) + \".pickle\"\n",
+    "    data.update(pickle.load( open( fil, \"rb\" ) ))\n",
+    "    \n",
+    "covariance = {}\n",
+    "for year in [2004]:\n",
+    "    fil = barra_dir + \"covariance.\" + str(year) + \".pickle\"\n",
+    "    covariance.update(pickle.load( open(fil, \"rb\" ) ))\n",
+    "    \n",
+    "daily_return = {}\n",
+    "for year in [2004, 2005]:\n",
+    "    fil = barra_dir + \"price.\" + str(year) + \".pickle\"\n",
+    "    daily_return.update(pickle.load( open(fil, \"rb\" ) ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shift Daily Returns Data (TODO)\n",
+    "\n",
+    "In the cell below, we want to incorporate a realistic time delay that exists in live trading, we’ll use a two day delay for the `daily_return` data. That means the `daily_return` should be two days after the data in `data` and `cov_data`. Combine `daily_return` and `data` together in a dict called `frames`.\n",
+    "\n",
+    "Since reporting of PnL is usually for the date of the returns, make sure to use the two day delay dates (dates that match the `daily_return`) when building `frames`. This means calling `frames['20040108']` will get you the prices from \"20040108\" and the data from `data` at \"20040106\".\n",
+    "\n",
+    "Note: We're not shifting `covariance`, since we'll use the \"DataDate\" field in `frames` to lookup the covariance data. The \"DataDate\" field contains the date when the `data` in `frames` was recorded. For example, `frames['20040108']` will give you a value of \"20040106\" for the field \"DataDate\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames ={}\n",
+    "dlyreturn_n_days_delay = 2\n",
+    "\n",
+    "# TODO: Implement\n",
+    "date_shifts = zip(\n",
+    "        sorted(data.keys()),\n",
+    "        sorted(daily_return.keys())[dlyreturn_n_days_delay:len(data) + dlyreturn_n_days_delay])\n",
+    "\n",
+    "for data_date, price_date in date_shifts:\n",
+    "    frames[price_date] = data[data_date].merge(daily_return[price_date], on='Barrid')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add Daily Returns date column (Optional)\n",
+    "Name the column `DlyReturnDate`.\n",
+    "**Hint**: create a list containing copies of the date, then create a pandas series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional\n",
+    "for DlyReturnDate, df in daily_return.items():\n",
+    "    # TODO\n",
+    "    n_rows = df.shape[0]\n",
+    "    df['DlyReturnDate'] = pd.Series([DlyReturnDate]*n_rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Winsorize\n",
+    "\n",
+    "As we have done in other projects, we'll want to avoid extremely positive or negative values in our data. Will therefore create a function, `wins`, that will clip our values to a minimum and maximum range. This process is called **Winsorizing**. Remember that this helps us handle noise, which may otherwise cause unusually large positions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wins(x,a,b):\n",
+    "    return np.where(x <= a,a, np.where(x >= b, b, x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Density Plot\n",
+    "\n",
+    "Let's check our `wins` function by taking a look at the distribution of returns for a single day `20040102`. We will clip our data from `-0.1` to `0.1` and plot it using our `density_plot` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEKCAYAAAAfGVI8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzt3Xd8ZGd97/HPT72v+mqbyq63eNdrdm153bBZm9gYG0IJSWwgmBKchJCE8kpCCOncXHITIHDhArbjxDhAIAYMxA64xGXBdZu9vUirrVpJq97bPPePc2YtC2k1kmbmzGi+79dLr5k5c8pPR5rzm6ec5zHnHCIikrrSgg5ARESCpUQgIpLilAhERFKcEoGISIpTIhARSXFKBCIiKU6JQEQkxSkRiIikOCUCEZEUlxF0AJEoLy93tbW1QYchIpJUduzYcc45VzHTekmRCGpra9m+fXvQYYiIJBUzOx7JeqoaEhFJcUoEIiIpTolARCTFKRGIiKQ4JQIRkRSnRCAikuKUCEREUpwSgcgcOed4+nAbj+xpDjoUkXlJihvKRBJN79AoH/7mdp5v7ADgA9fW8pnb1pOeZgFHJjJ7SgQic3DPtmM839jBX711PSc7BrnvF8dYXpLHh15fF3RoIrOmRCAyS+f6hvmXbY3curGKD1zrXfj3N3dz77ZG3nd1DZnpqnGV5KL/WJFZ+sbTDQyOjvOJm9aeX/Y716+iuXuIn7x8JsDIROZGiUBkFkIhx492n+Hm9VVcVFlwfvnWtRWsWVzAPduOBRidyNwoEYjMwsunumjtHeaWS6pes9zMuP2Kag4093C8vT+g6ETmRolAZBYe3d9CRppxw9rKX3rvxnXesicPtsY7LJF5USIQmYVH953lqpVlLMrL/KX3asvzWVmez/8cagsgMpG5UyIQiVBjWx8Nbf3ctH7xtOvcsK6S5xvbGRgZi2NkIvOjRCASoRePeTePXbe6fNp1blxXychYiF8cbY9XWCLzpkQgEqEdxzspzc+irjx/2nWuqC0lOyON5xuVCCR5KBGIRGjHiU4uqy7BbPphJLIy0rh0+SJ2nuiMY2Qi86NEIBKBjv4RGtv6ubymZMZ1L6suYd/pHobHxuMQmcj8KRGIRGCX/w0/kkSwubqYkfEQ+870xDoskahQIhCJwI7jnWSkGZcuXzTjupdVe8li53FVD0lyUCIQicDOE51sWFpETmb6jOtWFuWwrDiXXSe64hCZyPwpEYjMwDnH/jM9bFg2c2kgbHN1sRqMJWnELBGY2Qoze9LMDpjZPjP7I3/5X5vZaTPb7f/cGqsYRKLhTPcQPUNjXLykKOJtNq0oprl7iPa+4RhGJhIdsZyPYAz4pHNup5kVAjvM7DH/vS865/4phscWiZoDfqPv+iWFEW8TThoHmnt5/ersmMQlEi0xKxE455qdczv9573AAWBZrI4nEisHmr1EsLYq8hLBq4lAPYck8cWljcDMaoHNwAv+oo+a2Stmdp+ZzdwfTyRAB8/2Ul2aR0F25AXo0vwsFhdlKxFIUoh5IjCzAuD7wMeccz3A14BVwCagGfj8NNvdZWbbzWx7W5tGc5TgHGju4eJZVAuFXbykiP1KBJIEYpoIzCwTLwl8yzn3AwDnXItzbtw5FwLuAbZMta1z7m7nXL1zrr6ioiKWYYpMa2BkjGPt/bNqKA67eEkRDW19jIyFYhCZSPTEsteQAf8CHHDOfWHC8iUTVnsHsDdWMYjM16GzvTjHnBPB6LjjaGtfDCITiZ5Y9hq6FvgtYI+Z7faXfRq4w8w2AQ5oAn4nhjGIzMsR/yK+ZvHsq4bCvYwONPewfunsE4lIvMQsETjnfg5MNUzjI7E6pki0NbT2kZWexoqS3FlvW1deQHZGGgfPqp1AEpvuLBa5gIa2PurK88lIn/1HJT3NWFlRoKohSXhKBCIX0NDWz6rK6SeimclFlQUcbVMikMSmRCAyjeGxcY6393NRRcGc97G6soBTnYMMjmhuAklcSgQi0zjePkDIwarKuSeCiyoLcM6rYhJJVEoEItMI1+2vmmeJYOK+RBKREoHINBr8i/fKirm3EdSU5ZOeZkoEktCUCESm0dDWx7LiXPKy5t7LOisjjdqyPI609kYxMpHoUiIQmUZDW/+8SgNhF1WqC6kkNiUCkWkcb++nrnz+iWB1ZSFN7QMac0gSlhKByBS6B0bpGRqjujRv3vtaWZHPeMhxsnMgCpGJRJ8SgcgUTnR4F+0VUUgEtX6poulc/7z3JRILSgQiUwgngmiUCOrKvERwTIlAEpQSgcgUjnd4F+1olAhK8rMozstUIpCEpUQgMoWTHQOU5WfNanrKC6kty6epXYlAEpMSgcgUTnQMRKU0EFZXns+xNiUCSUxKBCJTONExQE1ZdBPBme4hhkY1+JwkHiUCkUlGx0Oc6RqKSkNxWLjn0PF2dSGVxKNEIDJJc9cQ4yEX1aqhleXhnkO6w1gSjxKByCThHkOxKBEcO6cSgSQeJQKRSaJ5D0FYQXYG5QXZKhFIQlIiEJnkRMcAWelpLC7Kiep+V5bn06QSgSQgJQKRSU52DLC8JJf0NIvqfmvL8zimewkkASkRiExyomOA6ih2HQ2rLc+nrXeY3qHRqO9bZD6UCEQmOdE+ENX2gbCV6kIqCUqJQGSCroGRqA0/PVm451CjxhySBKNEIDJBNIefnqymVMNRS2JSIhCZIBZdR8Nys9JZuihHiUASjhKByASxLBGAVz2kqiFJNDFLBGa2wsyeNLMDZrbPzP7IX15qZo+Z2RH/sSRWMYjMVrSHn56srlzDUUviiWWJYAz4pHPuYuAq4PfNbD3wKeAJ59xq4An/tUhCiFXX0bC68ny6Bkbp7B+J2TFEZitmicA51+yc2+k/7wUOAMuAtwH3+6vdD7w9VjGIzNaJjth0HQ2r9aetVKlAEklc2gjMrBbYDLwALHbONYOXLIDKaba5y8y2m9n2tra2eIQpKS4Ww09PVlvu7Vv3EkgiiXkiMLMC4PvAx5xzPZFu55y72zlX75yrr6ioiF2AIr4zXYNRH356shWleZhpIntJLDFNBGaWiZcEvuWc+4G/uMXMlvjvLwFaYxmDSKRi2XU0LDsjnaWLcjmuqiFJILHsNWTAvwAHnHNfmPDWj4E7/ed3Aj+KVQwisxGPRADhwedUNSSJI5YlgmuB3wJuNLPd/s+twOeAm8zsCHCT/1okcLEafnqy2rJ8lQgkocSmszTgnPs5MN04vm+M1XFF5upkxwDLS6M//PRktWVeF9KugRGK87JieiyRSOjOYhHf8RiNOjpZePC5JlUPSYJQIhABnHMxG356stqycBdSVQ9JYlAiEAG6B0fpHY7N8NOTqQupJBolAhFiP9jcRDmZ4S6kqhqSxKBEIEL8uo6G1ZTlqUQgCUOJQIT4lgjAazBWG4EkCiUCEbyuo+UFsRt+erLasjw6B0bpHtBE9hI8JQIRvK6j8SoNgEYhlcSiRCBC7IefnuzVewmUCCR4SgSS8rzhpwfjmgjCx2o6p55DEjwlAkl5Z7oGCbn4NRRDuAtpjhqMJSEoEUjKi3fX0bCasnyOKRFIAlAikJQXVCLwupCqakiCp0QgKe9Euzf8dFWMh5+erLYsj47+EboH1YVUgqVEICnvhD/8dFqMh5+eLNxzSO0EEjQlAkl58e46GvbqvQSqHpJgKRFISovn8NOTvdqFVCUCCZYSgaS0eA4/PVluVjpLFuXopjIJnBKBpLR4DzY3WU1ZnkoEEriIEoGZfd/MbjMzJQ5ZUMLdN4MoEQDUqQupJIBIL+xfA94NHDGzz5nZuhjGJBI3Qd1DEFZTlk97/wg9Q+pCKsGJKBE45x53zr0HuAxoAh4zs2fN7ANmlhnLAEViKTz8dH6chp+e7Pz8xRpzSAIUcVWPmZUB7wd+G9gFfAkvMTwWk8hE4uBER3yHn55Mo5BKIojoa5CZ/QBYBzwAvNU51+y/9V0z2x6r4ERi7UTHAJfXlAR2/JpSPxGowVgCFGl5+F7n3CMTF5hZtnNu2DlXH4O4RGIuPPz0OzYvCyyG3Kx0qopyNPicBCrSqqHPTrHsuWgGIhJvQQw/PZW68nxNZC+BumCJwMyqgGVArpltBsKDsRQBwX56ROYp6K6jYasq8/nR7jM45zCL73hHIjBz1dCb8BqIlwNfmLC8F/j0hTY0s/uAtwCtzrlL/GV/DXwYaPNX+/TkKieReAl3Ha0pCzYRXFRRQO/QGG19w1QWxncEVBGYIRE45+4H7jezX3POfX+W+/434CvANyct/6Jz7p9muS+RqDvRMUBWRhqLA774rqosAOBoa58SgQRipqqh9zrn/h2oNbNPTH7fOfeFKTYLv/eMmdXOO0KRGGk6109NaV7ch5+e7CI/ETS09XPNqvJAY5HUNFNjcb7/WAAUTvEzFx81s1fM7D4zm7bfnpndZWbbzWx7W1vbdKuJzNnx9gFqyvJnXjHGqopyyM9Kp6G1L+hQJEXNVDX0Df/xb6J0vK8Bfwc4//HzwAenOfbdwN0A9fX1LkrHFwEgFHIc7+jnutXBfwM3M1ZVFtDQpkQgwYh00Ln/Y2ZFZpZpZk+Y2Tkze+9sD+aca3HOjTvnQsA9wJbZ7kMkGlp6hxgaDVFTHnyJAGBVRQFHVSKQgER6H8HNzrkevF5Ap4A1wB/P9mBmtmTCy3cAe2e7D5FoaPLH9qkNuMdQ2EWVBTR3D9E3PBZ0KJKCIr2zODyw3K3Ad5xzHTP1dzaz7wBbgXIzOwX8FbDVzDbhVQ01Ab8zh5hF5i08T3BtArQRAKyq8OJobOvj0uXFAUcjqSbSRPATMzsIDAIfMbMKYOhCGzjn7phi8b/MMj6RmGhqHyAz3ViyKDG6a77ac0iJQOIv0mGoPwVcDdQ750aBfuBtsQxMJJaOt/ezojSPjPTEmGupujSf9DRTO4EEYjaDsF+Mdz/BxG0m3ywmkhSa2gcSploIICsjjZqyPBpaNeaQxF+kw1A/AKwCdgPj/mKHEoEkIeccx9v7uWpladChvMaqigKOqgupBCDSEkE9sN45p/78kvTa+oYZGBlPqBIBeO0ETx1qZXQ8RGaCVFlJaoj0v20vUBXLQETiJdx1NOjB5iZbVVHA6Lg7PxieSLxEWiIoB/ab2YvAcHihc+5XYxKVSAw1JVjX0bDzPYda+1hVURBwNJJKIk0Efx3LIETi6Xh7P+lpxrKS3KBDeY2V/r0EDW1qMJb4iigROOeeNrMaYLVz7nEzywPSYxuaSGw0tQ+woiQ34erhi3IyWVyUrS6kEneRjjX0YeBB4Bv+omXAQ7EKSiSWjrf3J8Soo1O5qLKAo629QYchKSbSr0S/D1wL9AA4544AlbEKSiRWnHMcPzeQMGMMTbZ2cRGHW/oYD6mDnsRPpIlg2Dk3En7h31Sm/1RJOh39I/QOjyVsiWBdVSGDo+PqOSRxFWkieNrMPo03if1NwH8CP4ldWCKx0eRPWF9bnqAlgipvvqdDZ3sCjkRSSaSJ4FN4E87vwRsx9BHgM7EKSiRWwqOOJmqJYM3iQszgQLPaCSR+Iu01FDKzh4CHnHOaN1KSVtO5ftIMlidY19Gw3Kx0asvyOXRWiUDi54IlAvP8tZmdAw4Ch8yszcz+Mj7hiURXQ5s36mh2RuL2fl5XVchBVQ1JHM1UNfQxvN5CVzjnypxzpcCVwLVm9vGYRycSZQ1tfVyU4Hftrq0q5HjHAAMjmq1M4mOmRPA+4A7n3LHwAudcI/Be/z2RpDEecjSe62dVZWIngnVVhTgHh1t0Y5nEx0yJINM5d27yQr+dIHOK9UUS1unOQUbGQuenhUxU65csAmD/GVUPSXzMlAhG5vieSMJp8Mf6T/QB3VaU5lKYk8HeM91BhyIpYqZeQ68zs6m+lhiQGJO9ikQoWRKBmXHJ0kXsO61EIPFxwRKBcy7dOVc0xU+hc05VQ5JUGtr6KM3PoiQ/K+hQZnTJsiIOnO1ldDwUdCiSAhJr+EWRGGpo7U/4HkNhlyxbxMhYSCORSlwoEUjKONrWx6rKxG4oDtuw1Gsw3qvqIYkDJQJJCR39I3T0jyR8+0BYXXk+eVnp7FPPIYkDJQJJCYdbvCEb1iwuDDiSyKSnGeuXFLFHJQKJAyUCSQnhRBAe3TMZXLq8mL2nu9VgLDGnRCAp4eDZXhblZlJZmB10KBHbXF3M8FiIgxqJVGIsZonAzO4zs1Yz2zthWamZPWZmR/zHklgdX2Siw2d7Wbu4EDMLOpSIbVpRDMDuk50BRyILXSxLBP8G3DJp2aeAJ5xzq4En/NciMeWc41BLL2uqkqOhOGx5SS7lBdnsOtEVdCiywMUsETjnngE6Ji1+G3C///x+4O2xOr5I2NmeIXqHxlibJA3FYWbG5upidp9UIpDYincbwWLnXDOA/1g53YpmdpeZbTez7W1tmgtH5i48yUuy9BiaaHN1MY3n+uns19BeEjsJ21jsnLvbOVfvnKuvqKgIOhxJYsnWdXSiV9sJVCqQ2Il3ImgxsyUA/mNrnI8vKehgcy+VhdlJMcbQZJtWFJORZrzUNLmWVSR64p0Ifgzc6T+/E/hRnI8vKWjfmR42LC0KOow5ycvKYOPyRbxwTIlAYieW3Ue/AzwHrDWzU2b2IeBzwE1mdgS4yX8tEjNDo+Mcbes7P3ZPMrqyroxXTnUxODIedCiyQM00H8GcOefumOatN8bqmCKTHW7pZTzkWJ+kJQKAK+tK+frTDew60ck1F5UHHY4sQAnbWCwSDeFB25K1agigvraENIPnVT0kMaJEIAvavjPdFGZnsKIkL+hQ5qwwJ5MNSxfxQmN70KHIAqVEIAvavjM9XLy0iLS05BlaYipXrypj14kuBkbGgg5FFiAlAlmwxkOOg829SV0tFHbd6nJGxkO80KjqIYk+JQJZsBra+hgcHeeSJO4xFHZFbSk5mWk8fVh32Uv0KRHIgrXbH6xtU3VxwJHMX05mOlfWlfHMESUCiT4lAlmwdp3soigng7qy5JineCbXr6mgsa2fU50DQYciC4wSgSxYu0508roVxUnfUBz2hjXePQRPHlKpQKJLiUAWpP7hMQ639LK5euHMfbSqooDasjwe3Xc26FBkgVEikAVpz+luQg42r0j+9oEwM+NNG6p4rqGd7sHRoMORBUSJQBak8Kxer1tAiQDg5g1VjIUcTx7UwL0SPUoEsiDtPNFJbVkepUk49PSFbF5RTGVhNj9T9ZBEkRKBLDihkOOlpg621JUGHUrUpaUZN29YzJOHWukb1l3GEh1KBLLgHGrppWtglCvryoIOJSbetmkZQ6MhNRpL1CgRyIITHpztypULr0QAUF9TworSXH6463TQocgCoUQgC84LxzpYVpzL8iQecfRCzIx3bFrGL46eo6VnKOhwZAFQIpAFxTnHi8c6FmxpIOztm5cRcqhUIFGhRCALyuGWPtr7R7hqgbYPhK2sKGBLXSnfeuE4oZALOhxJckoEsqA8fdjrX//61Qt/Ssf3XV3DyY5BjUgq86ZEIAvK04fbWLO4gKXFuUGHEnM3r6+iojCbB54/HnQokuSUCGTB6B8e46VjnWxdWxl0KHGRlZHGHVuqefJQK0dbe4MOR5KYEoEsGM82tDMyHmLrmoqgQ4mb919TS05GOl97qjHoUCSJKRHIgvHUoVbystK5vHbhjDg6k9L8LO7YUs1Du09zskPzFMjcKBHIghAKOR7b38J1q8vJzkgPOpy4+vD1daQZfPXJo0GHIklKiUAWhJ0nOmntHebWjUuCDiXulizK5b1X1fC97Sc50qK2Apk9JQJZEB7e00xWRhpvvHhx0KEE4g9uXE1+Vgaf+++DQYciSUiJQJJeKOT46d6zvGFNBQXZGUGHE4jS/Cw+csNFPHGwlScPaa4CmZ1AEoGZNZnZHjPbbWbbg4hBFo6dJzpp7h7i1o1VQYcSqA++vpZVFfn8xUN7GRwZDzocSSJBlghucM5tcs7VBxiDLADf236S/Kx0bl6f2okgOyOd//WOjZzqHOSLjx8OOhxJIqoakqTWNzzGf73SzFsuXUp+ilYLTXTVyjLefWU192xr5NmGc0GHI0kiqETggEfNbIeZ3TXVCmZ2l5ltN7PtbW0aS0Wm9vArZxgYGec3rlgRdCgJ4zO3XUxdWT6f/N7LdPSPBB2OJIGgEsG1zrnLgDcDv29m109ewTl3t3Ou3jlXX1GROneKSuScc3z7xZNcVFnAZdULa5L6+cjLyuBLt2+mvX+EP/jOTsbGQ0GHJAkukETgnDvjP7YCPwS2BBGHJLftxzt5+WQXd15Ti5kFHU5C2bh8Ef/r7Zfwi6Pt/P0j6lIqFxb3RGBm+WZWGH4O3AzsjXcckvy+8XQjJXmZvOuy5UGHkpB+vX4FH7y2jvt+cYx7t2ksIpleEK1ri4Ef+t/gMoBvO+d+GkAcksSOtvbx+IEW/vCNq8nNSq0hJWbjz2+7mLM9g3z24QPkZKbz3qtqgg5JElDcE4FzrhF4XbyPKwvLFx47RF5WOu+7Whe2C0lPM77wG5sYHt3JZx7ay/BYiA+9vi7osCTBqPuoJJ2XT3bxyJ6z/PZ1KykvyA46nISXk5nO1957OW++pIq/+6/9GpxOfokSgSQV5xz/+78PUJqfxYev0zfbSGVlpPF/79jM2zYt5R9/dohP/3API2PqTSQe3YEjSeUHO0/zfGMHn337JRTmZAYdTlLJSE/jC7+xiaXFuXztqQYOne3la++5jMqinKBDk4CpRCBJo6N/hM8+vJ/Lqot595bqoMNJSulpxp/eso6vvvsy9p/p4a1f+bnuQBYlAkkOzjn+5MFX6Bse4+/fuZG0NN03MB+3XbqEH3zkGvKzMnj3PS/wtz/Zz9CoBqpLVUoEkhTuf7aJxw+08Ke3rGNdVVHQ4SwIFy8p4uE/vI47r67hvl8c47Yvb+Olpo6gw5IAKBFIwnv26Dk++/AB3riuUl0foyw3K52/edslPPChLQyOjPPrX3+OT3xvN229w0GHJnGkRCAJ7XBLL7/z7ztYWZHPF2/fpKEkYuS61RU8/sk38JGtq/jJy2e48Z+e4mtPNWhegxShRCAJ60hLL+++53lyM9O57/1XUKReQjGVl5XBn9yyjp9+7Hrqa0v4h58e5Pp/fJJvPtekrqYLnBKBJKRXTnVxxz3PY2Z8566rWF6SF3RIKWNVRQH/+oEt/OfvXk1dWT5/+aN93Pj5p/je9pNKCAuUOeeCjmFG9fX1bvt2zWiZKn669ywf/+5uygqy+OYHt7CyoiDokFKWc45njpzjn352iD2nu6kqyuED19Zyx5XVKqElATPbEckskEoEkjCGx8b5wqOH+cYzjbxuRTH3vO9yKgt1s1MicM7x9OE27n6mkWcb2inIzuDdV1bzvqtrVFpLYEoEklR2n+zij//zZY609vHeq6r5i7esJztDo4omor2nu7n7mUYe3tNMyDm2rqng3VfWcMPaCjLSVducSJQIJCn0Do3yf//nKPdua2RxUQ5//86N3LC2MuiwJAKnuwb57osn+I+XTtLaO0xVUQ6/ecUK3nnZMmrK8oMOL+l09o+w+1QXDa19dPSP4ICinExu27iE6rK5lbqUCCShjYyF+PYLx/ny/xylo3+EO7as4M9uvVj1zklobDzEEwdb+dYLJ9h2pA3nYHN1MW/ftIy3XLqEMo0QO62BkTEe2nWGB3ecZNfJLsKX4/Q0w4CxkOOBD23hutVzm65XiUAS0tDoOD/YeZqvP93AiY4Brl5ZxqdvvZiNyxcFHZpEwZmuQX788hke2nWag2d7SU8zrr2onDdtWMxN6xerzcfX3D3IvduO8b3tJ+kdGmNdVSG3XFLFVSvLWFdVyKJc7wvR0GiIjHQjc45VbkoEklA6+kf47ksnue8Xx2jrHWbjskV84uY1bF1ToZvEFqiDZ3t4aNcZ/ntvM8fbBzCDy6pLeNOGxdywtpKLKgtS7m/fPTjK159u4L6fH2M85HjzxiXceXUNl9eUxORcKBFI4JxzPNfYzndePMnP9p5lZDzEdavL+d03rOKaVWUpdxFIVc45DrX08rO9LTy6/yz7zvQAUFWUw3Wry7l+TQXXXlROaX5WwJHGzvDYOA88d5yvPHmUroFR3r5pKZ+8eS0rSmPb40qJQAJz7Fw/j+xp5sEdpzh2rp+inAzeedly7thSzdqqwqDDk4Cd7hpk2+E2th05x8+PnqN7cBQz2LhsEVetLOOK2lLqa0ooWQCJIRRy/OSVM/zjzw5xqnOQ61aX86e3rOOSZfGpClUikLhqbOvjkT3NPLznLAeavW98W2pLuePKFbz5kiXkZKorqPyy8ZDjlVNdbDtyjm1H2nj5ZDcj497dy6srC7iirpQttaVsri6mujQvaUqRzjkeP9DK5x89xMGzvaxfUsSf3bpuzo2+c6VEgJeNx53DOQg5R0aaqZ9zlPQPj/F8YzvPHG7jmSPnOHauH4DLqou5deMSbt24hKXFuQFHKclmaHScV05181JTBy8e62Dn8U56h8cAWJSbyaXLF7Fx2SIuXV7MpcsXsWRRTkIlh/GQ44kDLXz1yaO8fKqb2rI8Pn7TGt566dJA5tBQIgD+4qG9PPD88fOvzaCyMJulxblUl+bxuuXFbKouZsPSIt28NIPuwVF2nuhkR1MnLzV1sPNEJ6PjjpzMNK5eWcYb1lRw84YqXfwlqsZDjoNne3j5ZDd7TnfxyqluDp3tZSzkXbdK8jJZs7iQdVWFrKnyHlcvLox7N+T2vmEe3HGKB54/zqnOQZYV5/JHb1zNOy9bFuiXTyUC4MlDrew91U1ammHmdcVq7hrkdNcgjW39nO0ZAiA7I40r/YvZG9ZUsKoiP6G+ZcRbz9AoB5t72X+mm/3NPd6Hr6UX57z+zRcvKfQv/pXU15ao2kfiamh0nAPNPew53c2B5h4Onu3l8Nle+icMmV1VlENteR61ZfnUlOVTV55HTVk+1aV55GfPf6r28ZCjoa2PZw638ej+FrY3dRBysKWulA9cU8tN6xcnRO2DEkEEznYPsftkFy8e6+Dpw600tHnVG8tLcnnDmgquX1PBVSvLzvfpXSicc/QOj9HSPcSpzkGOneunqb2fY+e8n1OM+nIlAAAMsklEQVSdg+fXLcvPYv3SIuprSqmvLWHTiuKofJBEosk5x6nOQQ639HLwbC8NbX0cbx+g6Vw/7f0jr1m3MDuDyqJsFhflsLgoh8qibCoKssnLyiAvK53crHTys7z/8dHxECPjIboGRjjbPczZniEaWvvYe6abAT/xrF1cyJs2LOa2S5cmXGcIJYI5ONkxwNOH23j6cBvPHj1H/8g4aX5vhqtXlXPNqjIurylJmAuhc46h0RC9w6P0Do35P6P0+c97hrzlfcNjtPd5/8QtPcO09Ayd/ycOK8zJoK48n9qyfNZWFbJ+aREblhRRUZid0qUjSX49Q6OcaB+gqb2fkx2DtPQM0dr76mehtWf4fAP1TMrys6gpy+PS5cVsXLaI+tqShB5OQ4lgnkbGQuw80cmzDe0813COXSe6GAs5zGBleT4bli5ibVUh1aV5rCjNY+miHBblZUbU1uCcY2Q8xNBIiL6RMf/CPXr+4t03/OpFvXfIe79n4uvhV5+H60ovJD8rndKCLBYX5rB4UQ5VRTks9r8RLSvOpa48n9L8LF3wJSU55+gZGmNwZJyBkTEGRsbPf1HKykgjM91YlJtJRWF20rUlKhFEWf/wGC81dbD7ZBf7zvSw73Q3Z7qHfmm9vKx0CrIzSE8z0sxIS4N0M0bHHUOj4wyOjjM0Ok4E12/S04zCnAwKsjMozMmkMCeDokmvC3K850U5Gf663vLCnAwKszMpyPFiEZHUE2kiCKSOw8xuAb4EpAP3Ouc+F0Qcs5GfncHWtZVsnTAyZv/wGKc6BznRMcDZ7kG6B0fpGvC+0Y+HHCG/2+p4yJGZnkZuVho5GV4dZE6m91OQnU5hTqZ/cX/1ol6Qk0FuZrq+pYtIzMU9EZhZOvBV4CbgFPCSmf3YObc/3rHMV352BmurChOugUhEZDaC6N+0BTjqnGt0zo0A/wG8LYA4RESEYBLBMuDkhNen/GWvYWZ3mdl2M9ve1tYWt+BERFJNEIlgqkrvX2o6dc7d7Zyrd87VV1TEd3wOEZFUEkQiOAWsmPB6OXAmgDhERIRgEsFLwGozqzOzLOB24McBxCEiIgTQa8g5N2ZmHwV+htd99D7n3L54xyEiIp5A7iNwzj0CPBLEsUVE5LWCHx5PREQClRRDTJhZG3B8xhWnVg6ci2I40aK4ZkdxzY7imp1EjQvmF1uNc27GbpdJkQjmw8y2RzLWRrwprtlRXLOjuGYnUeOC+MSmqiERkRSnRCAikuJSIRHcHXQA01Bcs6O4ZkdxzU6ixgVxiG3BtxGIiMiFpUKJQERELiBpE4GZlZrZY2Z2xH8smWa9n5pZl5n916TldWb2gr/9d/3hLjCzbP/1Uf/92hjFdae/zhEzu9NfVmhmuyf8nDOzf/bfe7+ZtU1477fjFZe//CkzOzTh+JX+8iDPV56ZPWxmB81sn5l9bsL6czpfZnaL/3seNbNPTfH+tL+vmf2Zv/yQmb0p0n3GMi4zu8nMdpjZHv/xxgnbTPk3jVNctWY2OOHYX5+wzeV+vEfN7Mtms5+daR5xvWfSZzBkZpv89+Jxvq43s51mNmZm75r03nSfzXmfL5xzSfkD/B/gU/7zTwH/MM16bwTeCvzXpOXfA273n38d+D3/+UeAr/vPbwe+G+24gFKg0X8s8Z+XTLHeDuB6//n7ga/E8nxdKC7gKaB+im0CO19AHnCDv04WsA1481zPF96QJw3ASn9/LwPrI/l9gfX++tlAnb+f9Ej2GeO4NgNL/eeXAKcnbDPl3zROcdUCe6fZ74vA1XgjFf93+G8aj7gmrbMRaIzz+aoFLgW+Cbwrws/mvM6Xcy55SwR4k9nc7z+/H3j7VCs5554Aeicu8zPmjcCDU2w/cb8PAm+cZYaNJK43AY855zqcc53AY8Atk2JcDVTiXdyiISpxzbDfuJ4v59yAc+5JAOdNcrQTbzTbuYpk0qTpft+3Af/hnBt2zh0Djvr7i8ZETHOOyzm3yzkXHt13H5BjZtmzPH7U45puh2a2BChyzj3nvKvcN5nmsx2HuO4AvjPLY88rLudck3PuFSA0adspPwNROl9JnQgWO+eaAfzH2RTTyoAu59yY/3ri5DjnJ87x3+/2149mXJFMznMH3reUia35v2Zmr5jZg2a2gtmJRlz/6heJ/2LChyYhzpeZFeOV/J6YsHi25yuSv8t0v+9020Y0EVMM45ro14BdzrnhCcum+pvGK646M9tlZk+b2XUT1j81wz5jHVfYb/LLiSDW52u220bjfAUz6FykzOxxoGqKt/58vrueYpmL4L1oxRXJ5Dy3A7814fVPgO8454bN7Hfxvs3cOHGDGMf1HufcaTMrBL7vx/bNGbaJR1yYWQbeB/bLzrlGf/GM52u2x5lhnemWT/Vla7Zd9eYTl/em2QbgH4CbJ7w/3d80HnE1A9XOuXYzuxx4yI8xoomrYhiX96bZlcCAc27vhPfjcb5mu200zldiJwLn3K9M956ZtZjZEudcs188ap3Frs8BxWaW4X8bmDg5TnjinFP+BWYR0BHluE4BWye8Xo5X/xjex+uADOfcjgnHbJ+w/j14H+rXiGVczrnT/mOvmX0br5j7TRLgfOH1sz7inPvnCcec8XxNc5yZJk2a7ve90LbznYhpPnFhZsuBHwLvc841hDe4wN805nH5Jd1h//g7zKwBWOOvP7F6L+7ny3c7k0oDcTpfF9p266RtnyI65yupq4Z+DIRbzu8EfhTphv4/4ZNAuFV+4vYT9/su4H8mVc9EI66fATebWYl5vWRu9peF/VLdpH+RDPtV4MAsYppXXGaWYWblfhyZwFuA8DelQM+XmX0W70P8sYkbzPF8RTJp0nS/74+B283rjVIHrMZrxIvGRExzjsuvMnsY+DPn3C/CK8/wN41HXBVmlu4ffyXe+Wr0qwd7zewqv+rlfczisz3fuPx40oBfx6vDx18Wr/M1nSk/A1E6X0nda6gMrz74iP9Y6i+vB+6dsN42oA0YxMueb/KXr8T7oB4F/hPI9pfn+K+P+u+vjFFcH/SPcRT4wKR9NALrJi3733iNfS/jJbF18YoLyMfrwfSKH8OXgPSgzxfetx+Hd5Hf7f/89nzOF3ArcBivd8ef+8v+FvjVmX5fvKquBuAQE3puTLXPOfy/zyku4DNA/4TzsxuvHWbav2mc4vq1CX+fncBbJ+yzHu8i2wB8Bf/G13jE5b+3FXh+0v7idb6uwLtO9QPtwL6ZrhnROF+6s1hEJMUlc9WQiIhEgRKBiEiKUyIQEUlxSgQiIilOiUBEJMUpEUhSM7Nx/5b/fWb2spl9wu8HfqFtlprZg/7zrTZpZNoZtp04qulBM/t4BNtsNbNrIj2GSLwl9J3FIhEYdM6FhwmuBL6Nd4PZX023gfMGYXvXdO9H4LvOuY+aWRlwyMwedM6dvMD6W4E+4NlID2Bm6c658XnEKBIxlQhkwXDOtQJ3AR81T62ZbTNvfPed4W/l/vLX3BVqZmnmjfNeMeH10fDdpNMcrx3v5p4l/jYVZvZ9M3vJ/7nWvHHufxf4uF+KuM7M/s0mjDVvZn3+41Yze9IfvmCPH+cBM7vHL/E8ama5/rp/aGb7zRtU7z8QmQclAllQnDfoXBre3bOtwE3OucvwRpL88gW2CwH/DrzHX/QrwMvOuXPTbWNm1Xh3qL7iL/oS8EXn3BV4d87e65xrwpvv4ovOuU3OuZmGFd+Cd8fpev/1auCrzrkNQJe/X/DmbtjsnLsUL9GIzJmqhmQhCo/ImAl8xbwZpsbxBjW7kPvwxmn5Z7zb+f91mvV+08xuANYCH3bODfnLfwVYb6+OTlxk3kiVs/Gi8+YzCDvmnNvtP9+BN3EJeMnnW2b2EPDQLI8h8hoqEciC4g9gNo5XGvg40AK8Dm88lqwLbevX87eYN53jlXizPU3lu/439OuAz5tZeIjtNOBq/5v/JufcMudc7xTbj/nrhidJmhhX/6R1J84dMM6rX95uA74KXA7s8EfQFJkTJQJZMPz6/a/jTVHp8BqNm/1qn9/CmypwJvfiVRF9b6bGWufcc8ADwB/5ix4FPjohnk3+015gYsmgCe8CDt4MVZkRxHWe3ytqhfNmZ/sToBgomM0+RCZSIpBklxvuPgo8jncx/hv/vf8H3Glmz+NVC03+tj2VH+NdVKerFprsH4AP+FVAfwjU+w24+3m17v4nwDvCjcV48yO8wcxexCt5RBLXROnAv5vZHmAXXvtD1yz3IXKeRh8VmcDM6vEurNfNuLLIAqF6RRGfmX0K+D1e7TkkkhJUIhARSXFqIxARSXFKBCIiKU6JQEQkxSkRiIikOCUCEZEUp0QgIpLi/j/1u2RagvoEEQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fbee7c3bf98>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def density_plot(data): \n",
+    "    density = gaussian_kde(data)\n",
+    "    xs = np.linspace(np.min(data),np.max(data),200)\n",
+    "    density.covariance_factor = lambda : .25\n",
+    "    density._compute_covariance()\n",
+    "    plt.plot(xs,density(xs))\n",
+    "    plt.xlabel('Daily Returns')\n",
+    "    plt.ylabel('Density')\n",
+    "    plt.show()\n",
+    "    \n",
+    "test = frames['20040108']\n",
+    "test['DlyReturn'] = wins(test['DlyReturn'],-0.1,0.1)\n",
+    "density_plot(test['DlyReturn'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Factor Exposures and Factor Returns\n",
+    "\n",
+    "Recall that:\n",
+    "\n",
+    "$r_{i,t} = \\sum_{j=1}^{k} (\\beta_{i,j,t-2} \\times f_{j,t})$  \n",
+    "where $i=1...N$ (N assets),   \n",
+    "and $j=1...k$ (k factors).\n",
+    "\n",
+    "where $r_{i,t}$ is the return, $\\beta_{i,j,t-2}$ is the factor exposure, and $f_{j,t}$ is the factor return. Since we get the factor exposures from the Barra data, and we know the returns, it is possible to estimate the factor returns. In this notebook, we will use the Ordinary Least Squares (OLS) method to estimate the factor exposures, $f_{j,t}$, by using $\\beta_{i,j,t-2}$ as the independent variable, and $r_{i,t}$ as the dependent variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_formula(factors, Y):\n",
+    "    L = [\"0\"]\n",
+    "    L.extend(factors)\n",
+    "    return Y + \" ~ \" + \" + \".join(L)\n",
+    "\n",
+    "def factors_from_names(n):\n",
+    "    return list(filter(lambda x: \"USFASTD_\" in x, n))\n",
+    "\n",
+    "def estimate_factor_returns(df): \n",
+    "    ## build universe based on filters \n",
+    "    estu = df.loc[df.IssuerMarketCap > 1e9].copy(deep=True)\n",
+    "  \n",
+    "    ## winsorize returns for fitting \n",
+    "    estu['DlyReturn'] = wins(estu['DlyReturn'], -0.25, 0.25)\n",
+    "  \n",
+    "    all_factors = factors_from_names(list(df))\n",
+    "    form = get_formula(all_factors, \"DlyReturn\")\n",
+    "    model = ols(form, data=estu)\n",
+    "    results = model.fit()\n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "facret = {}\n",
+    "\n",
+    "for date in frames:\n",
+    "    facret[date] = estimate_factor_returns(frames[date]).params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_dates = sorted(list(map(lambda date: pd.to_datetime(date, format='%Y%m%d'), frames.keys())))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Choose Alpha Factors\n",
+    "\n",
+    "We will now choose our alpha factors. Barra's factors include some alpha factors that we have seen before, such as:\n",
+    "\n",
+    "* **USFASTD_1DREVRSL** : Reversal\n",
+    "\n",
+    "* **USFASTD_EARNYILD** : Earnings Yield\n",
+    "\n",
+    "* **USFASTD_VALUE** : Value\n",
+    "\n",
+    "* **USFASTD_SENTMT** : Sentiment\n",
+    "\n",
+    "We will choose these alpha factors for now, but you are encouraged to come back to this later and try other factors as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.6/site-packages/pandas/plotting/_converter.py:129: FutureWarning: Using an implicitly registered datetime converter for a matplotlib plotting method. The converter was registered by pandas on import. Future versions of pandas will require you to explicitly register matplotlib converters.\n",
+      "\n",
+      "To register the converters:\n",
+      "\t>>> from pandas.plotting import register_matplotlib_converters\n",
+      "\t>>> register_matplotlib_converters()\n",
+      "  warnings.warn(msg, FutureWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEKCAYAAADjDHn2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzs3Xd4VEXbwOHfZNM7CSEEQgqhhha6IGoIiCAoxQLoBygqFhDE1/IqvIpiB8WGChaKAqGJgII0Aek99BYgIaGlk9525/vjJEsCKZuypDD3deVi99Rnl2SfPWdmnhFSShRFURSlJBZVHYCiKIpS/alkoSiKopRKJQtFURSlVCpZKIqiKKVSyUJRFEUplUoWiqIoSqlUslAURVFKpZKFoiiKUiqVLBRFUZRSWVZ1AJWlbt260s/Pr6rDUBRFqVEOHDgQJ6X0KG27WpMs/Pz82L9/f1WHoSiKUqMIISJN2U7dhlIURVFKpZKFoiiKUiqVLBRFUZRS1Zo2i6Lk5OQQHR1NZmZmVYeiVHO2trZ4e3tjZWVV1aEoSrVUq5NFdHQ0Tk5O+Pn5IYSo6nCUakpKSXx8PNHR0fj7+1d1OIpSLdXq21CZmZm4u7urRKGUSAiBu7u7ugJVlBLU6mQBqEShmET9nihKyWp9slAURanN5u2MYEd4nNnPo5KFoihKDfXvmVjeW32cJfujzH4ulSzMLCIigtatWxdaNmXKFKZPn87u3bvp2rUrQUFBtGzZkilTpgAwd+5cPDw8CAoKIigoiJEjRxr3zc3NpW7durz11luFjvnnn3/Svn172rVrR2BgILNmzeLDDz80HkOn0xkff/3110yZMoWGDRsSFBRE06ZNGTJkCCdOnCjxtXz77bc0adIEIQRxcTe+yeTH2759e5o2bcoDDzzAzp07jeufeuop/P39CQoKol27dmzatMm4Ljg4mObNmxtje/TRR9myZQvdunUrdO7c3Fw8PT25cuVKiccr6n0o+J4rSm1wPjaVsQsOMvKXvfjXdeDDwW3Mf1IpZa346dixo7zZiRMnbll2u124cEG2atWq0LJ3331XTps2TTZr1kyGhYVJKaXMzc2Vx48fl1JKOWfOHDl27Ngij/fXX3/J7t27y8aNG0uDwSCllDI7O1t6eXnJqKgoKaWUmZmZ8tSpU4X2c3BwKDKGfKGhodLT01PGxMQU+1oOHjwoL1y4IH19fWVsbKxx+c3x/vPPP9LT09P4/o8aNUouXbrUuK5JkybGbe+77z65b9++QufR6/XS29tbXrhwwbhs7dq1MiQkpMTjlfQ+3Px6i1Idfl8UpTT7I+Jlk7f/ki3/t1Z+vv60TM7IrtDxgP3ShM/YWt11tqD3Vh/nxOXkSj1mYANn3n2oVbn3j4mJwcvLCwCdTkdgYGCp+yxatIgJEybw/fffs3v3brp160ZKSgq5ubm4u7sDYGNjQ/PmzcsUy9ChQ/nrr79YuHAhEyZMKHKb9u3bm3Ssnj17MmbMGGbPns2MGTMKrevWrRuXLl0qcX8LCwsee+wxFi9ezJtvvglAaGgow4cPv2XbgserjPdBUaqzjGw9ry09gqezLb+/1J16Tra37dzqNlQVmjhxIs2bN2fw4MHMmjWrUNfNxYsXG2/NzJkzB4CMjAw2bdrEgAEDGD58OIsWLQLAzc2Nhx9+GF9fX4YPH86CBQswGAxljqdDhw6cOnWqUl5bccf6+++/GTRoUKFlTz75pPG1vv766wAMHz6c0NBQALKyslizZg2PPPJIicerrPdBUaqraetOcyEujc8ebXtbEwXU8kF5BVXkCqAiiuuSKYTgnXfe4cknn2T9+vUsXLiQRYsWsWXLFkD7pv/tt98W2ufPP/+kZ8+e2Nvb88gjjzB16lRmzJiBTqfjp59+4ujRo2zcuJHp06ezYcMG5s6dW6ZYtSvSynHzsV5//XXeeOMNYmJi2L17d6F1CxYsoFOnToWWde7cmdTUVE6fPs3Jkye56667qFOnTqnHq4z3QVGqo8j4NObtiuDJrj50D6h728+vrizMzN3dncTExELLEhISqFtX+88OCAjgxRdfZNOmTRw+fJj4+Phij7Vo0SI2btyIn58fHTt2JD4+ns2bNxvXt2nThokTJ7JhwwaWL19e5lgPHTpEy5Yty7yfKceaNm0a4eHhfPDBB4waNcqkYwwbNozQ0NAib0GVdLyKvg+KUh0kpWeTmaM3Pv/2n3AsLQQTejWtknhUsjAzR0dHvLy8jD12EhIS+Pvvv+nRowd//fWX8Rv42bNn0el0uLq6Fnmc5ORktm/fzsWLF4mIiCAiIoKZM2eyaNEiUlNTjVckAGFhYfj6+pYpzuXLl7N+/foi2wXKauvWrcyePZvnnnuu0HILCwsmTJiAwWBg3bp1pR5n+PDh/Pbbb/zzzz88/PDDt6y/+XiV8T4oSnUwbd0pgt7fQNv31vPkT7uZseEMvx+6xJNdfannfHtvP+VTyeI2mD9/Ph988AFBQUGEhITw7rvvEhAQwK+//mrsNjpixAgWLFiATqcr8hi///47ISEh2NjYGJcNHDiQVatWodfr+eyzz4zHevfdd0269TJjxgxj19n8D2UPj+InzPr666/x9vYmOjqatm3b8uyzzxrX5bexNGvWjI8++ojly5cXeZUihGDy5Ml89tlnxmUF2yx69+5tXB4YGIi9vT0hISE4ODgUGVPB40kpS3wfPvjgA7y9vY0/ilIdZecamL8zkkAvZ0be5Ut8ajZfbTqLtc6CF+5rXGVxicq8T12VOnXqJG+eKe/kyZOVdltFqf3U74tSHfx7JpaRv+zlp5Gd6B3oCUBMSiaZ2QZ83O0r/XxCiANSyk6lbXfHNHAriqLUBKsOX8bOSkePpjcasW93z6eiqGSh3GLw4MFcuHCh0LJPP/2UBx54oIoiUpQ7w4W4NFaGXWJ4Fx9srYq+JV1VVLJQbrFixYqqDkFR7gi5egNp2XrOx6by47bzrDt+DSud4NkeVdc2URyVLBRFUarIpBXHWH4wGr2UONta8WwPf/7vLl8auVV+20RFqWShKIpSBQ5HJbE4r1rsqG6+vNG3BQ421fcj2axdZ4UQfYUQp4UQ4UKI/xax3kYIsThv/R4hhF/ecishxDwhxFEhxEkhxFs376soilJTHY2+zqg5e6nvbEvYO/fz3sDW1TpRgBmThRBCB8wE+gGBwHAhxM2V8p4BEqWUTYAZwKd5yx8DbKSUbYCOwPP5iURRFKUmO3gxkSd+2o2DtSVLnu+Gq711VYdkEnNeWXQBwqWU56WU2UAoMPCmbQYC8/IeLwN6Ca2YkgQchBCWgB2QDVRuydjbpDbNZ1HU3BMFtWvX7pYR4KXNZVGwJtT+/fsJDg4mJiYGf39/rl69alz30ksv8cknn7BlyxYGDBhgfJ/GjRt3S5x+fn60adOGNm3aEBgYyOTJk8nKyirxtSnK7bDnfDwjftqDm4M1S17oZpZxE+ZizmTRECg4fVN03rIit5FS5gLXAXe0xJEGXAEuAtOllAlmjLVKjBo1itmzZxMWFsaxY8d4/PHHjeuGDh1KWFgYYWFhzJ8/37h8/fr1NG/enCVLlhhLheTk5DBmzBhWr17N4cOHOXToEMHBwUyaNMl4DDs7O+Pj8ePHA1rV27CwMM6ePcvQoUMJCQkhNja2xJgXLFhgPM6yZcuMy0+ePInBYODff/8lLS2t0D7Tpk0jLCyML7/8khdeeKHQupiYGNauXVtoWb169XjzzTd57bXXADh48CDbt2/nP//5j6lvLZs3b+bo0aPs3buX8+fPM2bMGJP3VRRz2Hw6hhE/76W+iy1Lnu9GQ1e7qg6pTMx5k6yocqs3DxcvbpsugB5oANQBtgkhNkopzxfaWYgxwBgAHx+fkqNZ+1+4etSkwE1Wvw30+6Tcu9e0+SxKsnDhQkaMGMHJkydZtWpVqXNP5Hv99df54IMP6NevX6HlY8aMYd68eWzevJlJkybx7bffYmVlVea4HB0d+eGHH2jUqBEJCQm4ubmV+RiKUhlmbT2Hl6sty17oTh2HmnHrqSBzXllEA40KPPcGLhe3Td4tJxcgAXgC+FtKmSOljAF2ALcMR5dSzpZSdpJSdiqpplF1VRPnsyhq7on8eIcOHVoorpsVNZdFt27dsLGxKVQ9F7Qigd9//z2PPPIIzZo149577y3z68nn7OyMv78/Z8+eLfcxFKUirmfksC8ikQFtvWpkogDzXlnsA5oKIfyBS8AwtCRQ0CpgFLALeBT4R0ophRAXgRAhxG+APXAX8GWFoqnAFUBF1Lb5LIqae2Lfvn14eHjg6+uLt7c3o0ePJjEx0Tj/RElzWQBMnjyZDz74gE8//bTQ8qCgIFq3bs1LL71UptdRlNpSA02pmbacjkFvkIS08KzqUMrNbFcWeW0Q44B1wElgiZTyuBDifSFEfr3pnwF3IUQ48CqQ3712JuAIHENLOnOklEfMFas53QnzWSxatIhTp07h5+dHQEAAycnJhc5f2lwWISEhZGZmFplILCwssLCo2K9pSkoKERERNGvWrELHUZTyWrDnIt517AhqVPQUBDWBWcdZSCnXSCmbSSkDpJQf5i17R0q5Ku9xppTyMSllEylll/w2CSllat7yVlLKQCnlNHPGaU61fT4Lg8HA0qVLOXLkiDGulStX3nIrqrS5LCZNmlSobHllSU1N5aWXXmLQoEGFZtpTlNvl1NVk9l5IYGQ3X3QWRd9pqAmq9yiQWmL+/PmMHTvW2Jsnfz6LSZMmMXHiROzt7bG0tCzXfBZvvPEGX3zxBZ999hnPP/88dnZ2ODg4mDyfxW+//UZaWhqtW7cudT4L0Nos7Oy0Xhx169Zl8uTJNGzYkIYNb3R0u/feezlx4gRXrlwptG/BuSduLkr44IMPlnruosydO5c//vjD+Dz/6qRnz55IKTEYDAwePJj//e9/ZT62olSGFQcvYWkheLRjo9I3rsbUfBaKkkf9viiVLSohncdn7aJFfSfmPN2lqsMpkprPQlEUpYocjkriiw1n+PdsLAL4aEibqg6pwlSyUG6h5rNQlPI7dDGR4T/uxsnWivEhTRnauRENatgAvKKoZKHcQs1noSjl9/n6MzjZWrFm/D14ONmUvkMNoZKFoihKOeToDczdEcEfYZfI0RvINUjc7K3ZH5nI6w80r1WJAlSyUBRFKVau3sDIX/bS3seV/9zfHAsLQXRiOglp2byx7AinrqbQybcOPm72WAjBteRMhndpxKjuflUdeqVTyUJRFKUY28Pj2Hkunp3n4jkSfZ241GxOXtEKYDvZWjJ7REf6tKpfxVHeHmYdlKfUnhLlU6ZMueWcYWFhhbqaHjp0CCHELYPuHB0dbzneU089VahqbcHtIiIisLOzM8YbFBRUqPKuophbeEwqLy86xFNz9uFka8krvZuy50IC9tY6JvdvyX/7tSB0zF13TKKAMl5ZCCEsAEcpZY2cW6K6GTVqFEuWLKFdu3bo9XpOnz5tXFdUbSgoXKL8o48+QghhLFG+d+9evL29ycrKIiIigubNmzNp0iRA+yAOCwszHmfKlClMnDjRWAZ88eLFhISEcPTo0SIHxw0fPpx+/frx8ccfG5eFhobyxBM3yn0tWrSIHj16sGjRogr3nAoICCgUr6KY219HrpCjN7DrXDxLD0RhZ6Wjs18d+gTW57l7GzM+pCkWNXgEdkWVemUhhFgohHAWQjgAJ4DTQojXS9tPKV1FSpT7+PgYRytXVonyPn36sHDhwiLXN2/eHFdXV/bs2WNctmTJEoYNGwZohfqWLVvG3LlzWb9+faEKuopS3R2JTmLswoO8sjiM3w9F81R3f/59oydLX+jOc/c2BrijEwWYdmURKKVMFkI8CawB3gQOADWqXtOnez/lVELJ5bfLqoVbC97s8ma5988vUR4cHEzfvn0ZNWoUtra2gPZNf/v27QBMmDCBp59+2liifNasWSQlJbFo0SK6detWqER5r169jCXMy1qAr7QS5cOHDyc0NJSuXbuye/du3N3dadq0KQA7duzA39+fgIAAgoODWbNmDUOGDCnnOwPnzp0jKCjI+Pybb77hnnvuKffxFKUkX248i5uDNa/0bkr3gLo0qXfrrdM7nSmfJlZCCCtgELBSSpnDrZMYKcUorUT5/v37jd/o+/bta1xfcKa8p59+Gri1RPmKFSvQ6/UA/PTTT2zatIkuXbowffp0Ro8eXeZYSyv9MmzYMJYtW4bBYCA0NLRQ0cFFixYZrzKGDRtW7JwWBV9/Scvyb0Pl/6hEoZhLZo6enefieLhdA0Z281OJohimXFnMAiKAw8C/QghfauB82BW5AqiI4kqU+/v7AzdKlD/33HN4eHiUWqJ8x44d+Pn5ARhLlPfu3RvAOO/0iBEj8Pf3L/N8FocOHbplroqCGjVqhJ+fH1u3bmX58uXs2rULAL1ez/Lly1m1ahUffvghUkri4+NJSUnBycmpyGPd/L4ULNuuKLfTvogEMnMM3Nes5k2gdjuVemUhpfxaStlQSvmg1EQCPW9DbLVCbStRPnz4cCZOnEhAQADe3t4AbNy4kXbt2hEVFUVERASRkZE88sgjharB3iw4OJjFixeTnZ0NaD3AevZUv1bK7SOl5M8jl5m4OAwnG0u6NlZT7pak1CsLIYQN8Ajgd9P275spplqnNpUof+yxx5gwYQLffPONcdmiRYsYPHhwoe0eeeQRvv/+e0aMGEF6eroxsQC8+uqrvPrqqxw4cICOHTui0+kICAjghx9+MG5zc5vF6NGjGT9+fKmvSVFMoTdIxi08yNpjV2nr7cInQ9pib62GnZWk1BLlQoi/getojdr6/OVSys/NG1rZqBLlSkWp35faLytXz8qwyyw7EM3eCwn85/5mvBgcgKXuzh1yVpklyr2llH1L30xRFKV6m/b3aX7arlVU7t2yHuNCmhTbCUUpzJRksVMI0UZKedTs0SjVgipRrtQmU1YdJzY1i8c6evNH2CX6BHoy7bF22FvrVKIoA1OSRQ/gKSHEBSALEICUUrY1a2RKlVElypXaIjUrl/m7IpBoI7QBhnRoiIudVZXGVROZkiz6mT0KRVEUMwi7mIRBwk8jO5GZq+fklWRCWnhWdVg1UonJIq8W1F9SytYlbacoilId7Y1IwEJA18ZuONlaMaBtg6oOqcYqsQuAlNIAHBZC+NymeBRFUSpFjt7AX0cu07qhC0626rZTRZlyG8oLOC6E2Auk5S+UUj5stqgURVEqKHTvRc7FpvHTyFJ7hSomMKVz8XvAALRBeJ8X+FFMUFvmsyjuHPmvJ/9Y+T9JSUls2bIFIQSrV682HmPAgAFs2bKFwYMHExQURJMmTXBxcTHut3PnToKDg/Hx8SlUq2rQoEE4Ojpy9OhR47Zubm74+/sTFBRkLHmiKKCNzp6/K5J2jVzp1bJeVYdTO0gpa8VPx44d5c1OnDhxy7Lb7cKFC7JVq1aFlr377rty2rRpslmzZjIsLExKKWVubq48fvy4lFLKOXPmyLFjxxZ5vL/++kt2795dNm7cWBoMBimllNnZ2dLLy0tGRUVJKaXMzMyUp06dKrSfg4NDkTHkCw0NlZ6enjImJqbI85Z0jpuPlW/z5s3S29tbdu3a1bisf//+cvPmzYW26d+/f6H97rvvPtmmTRu5bds2KaWUiYmJskuXLre8hlGjRsmlS5cWGW95VIffF6XsDAaDjIxLk/N2XpAjf94jxy08KEf9skf6vvmnXLQnsqrDq/aA/dKEz1hT5rNIEUIk5/1kCiH0QogaV0iwOqpJ81mU9xzt2rXDxcWFDRs2lCmeYcOGERoaCmilTipS7lyp3Rbsuci90zbzzsrjRMancezSdU5cTqZXi3o81E41aFeWUtsspJSFyoYKIQYBXcwWkZlc/egjsk5W7nwWNi1bUP/tt8u9f02az6K0c+TXmQKoU6cOmzdvNu47efJkJk+ezP33329yLL169eK5555Dr9cTGhrK7NmzmTp1aplej3JnWHHoEgBPdvVhysOtsLqDS3eYU5nfVSnlH0CIGWKplWrTfBYlnWPixInGeAsmCsA4F8W2bdtMjkWn09GjRw8WL15MRkaGsSy7ooD2u3roYiJvLDvMgchEXuvTjA8Ht1GJwoxMqTpb8PrfAuhEDZz8qCJXABVRm+azqMg5Jk2axIcffoilpemVPYcNG8bgwYONDf+Kkp1rYM6OC/x+8BKnr6VgZ6UjuLkHw7qo3v3mZkoafqjAzwNACjDQnEHVJrVlPouKnqNPnz4kJiZy+PBhk/e55557eOutt0qdY0O5c8zdeYGP157CzlrHx0PasHdSL+Y+3YW6jjal76xUiClf836SUu4ouEAIcTcQY56Qap/aMJ+FlLLEcxRsswCKnPho0qRJDBxo+vcMIQSvvfaaydsrtd/28Hia1nPkj7F3V3UodxxT5rM4KKXsUNqyqqbms1AqSv2+VG85egNtp6zn0Y7eTB2kKhBVlgrPZyGE6AZ0BzyEEK8WWOUMFP31V1EUxQwysvUET99MRo6euxq7V3U4d6SSbkNZA4552xTsPpsMPGrOoJSqpeazUKqbvREJXEvOYlBQA3oHqhHZVaHYZCGl3ApsFULMlVJGCiEcpJRpxW1fFCFEX+ArtCuRn6SUn9y03gaYD3QE4oGhUsqIvHVtgVloVzIGoLOUMrMs51fKR81noVQ3u8/HY6UTfDSkDTaW6sZGVTClgbuBEGIt2lWGjxCiHfC8lPKlknYSQuiAmcD9QDSwTwixSkpZsADRM0CilLKJEGIY8CkwVAhhCfwGjJBSHhZCuAM5ZX51aA2zajYspTSltd0pZZOUns3xy8mcj0vD1tICWysd15IzeaKrD/bWpX/s5OoNrDp8mexcA3GpWfx55DLtvF1N2lcxD1Pe+S/RusyuAsj78L7XhP26AOFSyvMAQohQtC63BZPFQGBK3uNlwLdC+2TvAxyRUh7OO2fxgw9KYGtrS3x8PO7u7iphKMWSUhIfH28cPa9UzOWkDPp9tY3rGbd+v7uYkM77A0tvnF595DKvLrnRzdrFzoqxwd6VGqdSNialaSll1E0ftnoTdmsIRBV4Hg10LW4bKWWuEOI64A40A6QQYh3gAYRKKT+7+QRCiDHAGAAfn1sH5Xh7exMdHU1sbKwJ4Sp3MltbW7y91YdRWew+H09iWjb92ngZl83bGcF7q49jbWnBnKc6413HjgHfbCcr10AjNzv+OHSJtx9sia1VybeSVh++grOtJX+NvwcPJ5tSt1fMz5RkESWE6I724W0NjAdOmrBfUV/lb77WL24bS7S5vzsD6cCmvO5dmwptKOVsYDZoXWdvPpCVlZVxpLSiKOV37NJ1tp7RvnRZCEFqVg4//nuBbL2BLx5vx5AO3kgpmbX1HAYJ3wzvQM8WWkP0Y528ORx1nTf6NmfEz3sJmb6FwAYuPBzUgIfzCv0ZDNL44RCflsW2s7E81d2PRm72VfFylSKYkixeQGukboh2dbAeGGvCftFAowLPvYHLxWwTnddO4QIk5C3fKqWMAxBCrAE6AJtQFOW2+9/KYxy6mGR8LgR08XNDCHh1yWGS0nPo4u/G5euZfPZoW+4PvDHP9fsPt0YCFgI+HtKGnefiORiZyMaT11i05yINXO1YfURrnyjoya5lq0KgmJcpVWfjgCcLLhNCOJhw7H1AUyGEP3AJGAY8cdM2q4BRwC607rj/SCnzbz+9IYSwB7KB+4AZJpxTUZRKdj09h8NRSYzr2YRxIU2QEiwswMZSR2aOngmhh3j/zxP4uNmjsxD0alG4a6uFxY0bCMO7+DC8iw8xKZl0+XATu85rzZHBzT3o4FOHHL2BRXujeLyTN351TfmYUW6XEpOFEKIh2rSqR6SU2UKIesArwFNAiYXi89ogxgHr0LrO/iKlPC6EeB9tso1VwM/Ar0KIcLQrimF5+yYKIb5ASzgSWCOl/KsCr1NRlHLadT4Og4T7mnvc0nZga6Xjuyc78u6qYyzYc5EPB7XB3YQ6TfWcbPnlqU5YCEGglzMeTjbGTiiv3t/MLK9DqZhiy30IIV4BJgHhgA3aragv0MZFfCalvHK7gjRFUeU+FEWpuNeXHubvY1c5+M79JZYAv56Rg4ud1W2MTKkMFS73gdbLqLmUMkEI4YOWNO6VUu6urCAVRaneMnP0/H3sKg+0rl/qXBEqUdRuJSWLTCllAoCU8qIQ4oxKFIpy5zh4MZF1x66SkpXLwCA1PemdrqRk4S2E+LrA83oFn0spx5svLEVRbrdjl67Tor4TmbkG3ll5jN8PatOVPtSuAXcH1K3i6JSqVlKyeP2m5wfMGYiiKFXnn1PXGD13P229XbiekUNUQjrjezWld8t6tG7gUqhHk3JnKqmQ4LzbGYiiKLdPWlYuDjban3+O3sAPW84DWjkON3trFj/fjc5+blUZolLNqKpcinKHWXX4MuMXHWL5i93wrmPP0Fm7iIhPZ3xIE17t07yqw1OqKZUsFOUOcvZaCq/lFehbsOciJy4nE5uSxeePtVON2EqJShuUpwPGSynV6GlFqeFy9QZGz9uHi70VTjaW/H7wElY6wZynutCjqWrAVkpWYsdpKaUerYy4oig13D+nYohKyGDqwFa8EByAEDBjaJBKFIpJTLkNtUMI8S2wGDDOlCelPGi2qBRFqVThMal8+vcpPJ1t6N3SE52FoHdLT9wcrKs6NKWGMCVZdM/79/0CyyQQUvnhKIpS2Zbsj+Ldlcexs9bxzfD2WOaNxFaJQikLU6rO9rwdgSiKUvkORyXxxrIjdGvszpfDgvB0VrMBKuVTcrEXQAjhIoT4QgixP+/ncyGEy+0ITlGUijl9LQWATx9pqxKFUiGlJgvgFyAFeDzvJxmYY86gFEWpHNEJ6VgIqO+iEoVSMaa0WQRIKR8p8Pw9IUSYuQJSFKXyRCdmUN/ZFmtLU74XKkrxTPkNyhBC9Mh/IoS4G8gwX0iKolSWqMR0vNU81kolMHUO7vkF2ikS0aZCVRSlmotOzKBbgHtVh6HUAqYki2QpZTshhDOAlDI5b15tRVGqsexcA1eTM2lUR11ZKBVnym2o5aAlCSllct6yZeYLSVGUyrAG4Oh3AAAgAElEQVQjPA4poaWXU1WHotQCxV5ZCCFaAK0AFyHEkAKrnAHVtUJRqrlfd0fi4WRDSAvPqg5FqQVKug3VHBgAuAIPFVieAjxnzqAURamYqIR0Np+OYVzPJqonlFIpSpr8aCWwUgjRTUq56zbGpChKBS3cexEBDO/iU9WhKLWEKV85XhBCuOY/EULUEUL8YsaYFEUxUXaugY0nrnH2WgonrySTnp2L3iBZfiCakBb1aOBqV9UhKrWEKb2h2kopk/KfSCkThRDtzRiToigmenfVcRbtvYiDtY60bD2u9laEtKhHTEoWA4MaVnV4Si1iSrKwEELUkVImAggh3EzcT1EUM/h1VwSWOgv6BHry5+HLtPRy5nxsKh18XHF3tOH3g5dwsNbRu6Vq2FYqjykf+p8DO4UQ+d1lHwM+NF9IilKzZecazNaoHBmfxv9WHgdg8h/H0Bskb/RtTsv6ztRxsMLGUkd4TCpZuXrsrHVmiUG5M5lSony+EOIA0BMQwBAp5QmzR6Yo1VxsShZrj12hnpMNTT2d8HWz59Ulh1l1+DLLX+xGR1+3Sj/nyrDLCAGz/q8jW8/Eci05k7sD6hZKTk3qOVb6eRXFpNtJUsrjQohY8sZXCCF8pJQXzRqZotwmK8Mu8fP2C4zt2YRGdewJbOBc6j7JmTk88OW/JKRlG5e5OVgbn284EWOWZLHm6BU6+7rRp1V9+rSqX+nHV5TimDKfxcNCiLPABWArEAGsNXNcimJWUkoAjl26zn+XH+VI9HWe//UAA2du59ddEcb1xdl2Jo6EtGx+HNmJVePuZmQ3X2OiaO7pxK7z8aXGkJmjZ/PpGAyGwuf6bks4j8/aRXauodDymJRMTl1NoWeLemV4pYpSOUy5sToVuAs4I6X0B3oBO8walaKYid4gmRB6iIEzd7AzPI7hs3fj5mDNjKHt+M/9zejRpC7/W3mc/yw9TGaOnvTsXKasOs6XG8+QnJljPM4/p2JwtbeiZ3MP2nq78p8+zQGo52RDn1aeHI1O4ur1zGLjkFIycXEYT8/Zx6Q/jhqX7wiP47O/T7P3QgIHIhML7bMjPA6Ae5rWrcy3RFFMYsptqBwpZbwQwkIIYSGl3CyE+NTskSlKJZNS8v7q46wMuwzAEz/tIcDDgd+e7YqXizYewWCQfP3PWb7ceJbTV1OwtdJx8GIiUsLS/dF88Xg7dp2PZ8WhaAa39zbOZ+1iZ8WKl7rj4WRDZo6Bn7dfYMyv+1k8pluRDc3f/BPO2mNXaevtwqK9UQzv4kNbb1f2R9xIEFtOxxSqGLv9bDx17K0I9Cr9NpmiVDZTriyShBCOwL/AAiHEV0CuecNSlMqVnp3L68uOMG9XJM/28OfuJu509K3D0he6GxMFgIWF4JXezfh5VCfOx6ZxIDKRL4cG8ftL3bHSCYb9uJsvN55lQNsGvPNQYKFztPepg3cde5rUc+SrYe05euk6ry4JK3SbyWCQTF93mi82nGFw+4b89mxXHKx1zNwcjt4gOX75Oo09HLi7iTt/hF0yXp1IKdkRHkf3JnWxsBC3501TlAJEafdmhRAOQCZaT6gnARdggZSy9Juyt1GnTp3k/v37qzoMpRwi49Oo72KLjWXldvVcGXaJrzae5eMhbZj8xzHCY1MZ17MJE3s3Ayj1Q/fYpetExKcxoG0DANKycvlk7SkiE9KZPaIjtlYlx/vTtvN88NdJXgwO4M2+LcjM0fPa0sP8eeQKwzo3Yuqg1ljpLPhq41lmbDxDcHMPTl1JoZNfHcbc25jhs3fj4+7A7y9251JSOr2/+JePh7RRJTyUSiWEOCCl7FTadiVVnb1LSrlbSplWYPG8SolOUfKcvJLMgG+208HHlZ+f6oyzrVWZ9k/PzuX1pUd4/YHm+NV1KLTuq01nOR+XxtDZu3F3sGb+6C7c09TD5GO3buhC64YuxucONpZMHdTa5P2f6eHP+bg0vt9yjlYNnNlzPoE/j1zhv/1a8Py9jRFCS1bjezWhrpM1U1YdJ0cvCWzgTFtvV759ogOj5+1j0oqjxh5aPZqo9gqlapTUZvEd0AFACLFLStmtrAcXQvQFvgJ0wE9Syk9uWm8DzAc6AvHAUCllRIH1PsAJYIqUcnpZz69UbwaDZOqfJ7Cz0nHoYhJP/riH+5p5sHDvRXL1Bl4IDuDF+wKMH6pF2X0+nr+OXiE2JYslL9z4FU3JzCEqIR0rnSCkRT3eH9gaT+fbW1lfCMF7D7fiSHQS4xYeAuD/7vLhhfsCbtnuya6+tPRy5ov1Z3ggr0tszxb1mNi7GV9sOMPaY1dp18iVRmqKVKWKlNRmUfAvtMx/ZUIIHTAT6AcEAsOFEIE3bfYMkCilbALMAG5uOJ+B6qZba/2y4wI7z8Xz334tmD2yI6evpfDt5nCCGrnS0bcOn/19mn9OxZR4jIi4dADOxqQUWr4jPJ4cveS3Z7oya0Sn254o8lnpLHi7X0sAvOvYMT6kabHbdvCpw2/PdiXA48agunE9m9C7ZT0ycvSM6uZr9ngVpTglXVlYCCHqoCWU/MfGBCKlTCjl2F2AcCnleQAhRCgwEO1KId9AYEre42XAt0IIIaWUQohBwHmg4G0wpZZIzszhq01n6dncgye7+iCEYOGzXTl0MYlnevijl5KOUzew9thVepVQ4yg/SSSma1cS+d+8d5+Px9bKgvY+dW7L6ylJ9yZ12fVWCPWcbNGVsXHawkLw5bD2bDp5jf5tvMwUoaKUrqRk4QIc4EaCOFhgnQQal3LshkBUgefRQNfitpFS5gohrgPuQogM4E3gfuC1Us6j1BARcWnsOBfH8cvJ7I9IICUzl//0aW68zdTJz41OftqoZwsEwc3rsflUDHqDLPZD9sy1VGPF1aOXrhuTxZ4LCXT0rVNtJv4p2OOqrBxtLFUFWaXKFfuXJKX0k1I2llL6F/FTWqKAwrexjIc1cZv3gBlSytQSTyDEGCHEfiHE/tjYWBNCUqqKwSB59IddTFpxjD8PX6auow1TB7Uu1IB8s96BnsSnZRMWpY090Bsk287G8saywySmZSOl5My1FB5s44XOQnDyijZF/PX0HE5dTaarv3uxx1YUpWzMWWo8GmhU4Lk3cLmYbaKFEJZoVzMJaFcgjwohPkOb1tUghMiUUn5bcGcp5WxgNmhdZ83yKpRKcT4ulbjULKY8FMio7n4lNlrnu6+ZB5YWgg0nYmhR35mHvtnO+TjtruTlpEzeerAFKZm5dPZ3IywqiROXtWSx+XQMUkIPNdJZUSqNOZPFPqCpEMIfuAQMA564aZtVwChgF/Ao8I/UBn7ck7+BEGIKkHpzolBqlvyRyfc08zApUYA2KrprYzc2nbxGfWcbzsel8XJIEzycbHhn5XHGLtDujHYPcGdHeBw7wuP488hllh+Mpp6TDUHerqWcQVEUU5nthq6UMhcYB6wDTgJL8qrXvi+EeDhvs5/R2ijCgVeB/5orHqVq7YtIxM3BmsY3jYUoTe+WnpyNSeXbzeF08NFqMI3s5sfIbr5ExKfj42aPdx177mnqQVxqNuMWHmLb2Tj6tq6vRjorSiUy6cpCCNEDaCqlnCOE8AAcpZQXSttPSrkGWHPTsncKPM5Em0yppGNMMSVGpXqSUnIuNo31J64S0qKeyVcV+Xq39OS91SeIS83mrbwuqACT+wdy9Xom7RppVw+PdvSmb+v6RCWkc+V6hlnKgyvKnazUZCGEeBfoBDQH5gBWwG/A3eYNTampsnL1SAm2Vjrm7Yxgymqtt/TIcowTaORmT3NPJ6IT0+nX5sb8DdaWFsweWbhCgaONJS29nGmpCu3VfBmJYFf13Z6VG0y5shgMtCev66yU8rIQwsmsUSk12ku/HWRfRAIju/mx7vhVAEbc5UuHco55mPJwK65n5GBvraZ+vyPEhcO3HaH7y9Dng/IfR0qI3AE6a2jUpfLiu0OZ0maRndfoLMFYWFBRipSZo2dbeBwONpbM3BLO2ZhUpg5qzdRBrct8CypftwB3+rZWs8LVelLC4VD4oYf2fOc3MK0pHF1WvuP9Ow3m9odfHoC4s9qyy2Hacn1OyfsqtzDlq9oSIcQswFUI8RwwGvjRvGEp1V18ahZ/HrlCRHwaUQnpXEvO4p2HAtEbJNm5BqYObI1fXQc2n4rhsY7eVR2uUt0lX4GVL8G5f7TngQPBsw2cWQvLn4FTf8KDn4ODiWNnrl+CbZ9Dw45w7QR81w2a99OuNNLjIWovDJwJjmrWQVOVmiyklNOFEPcDyWjtFu9IKTeYPTKl2opKSGfwdzuIS83G3lqHj5s9l5Iy+GrjWTr7uSEEdPZ3w8XOiib1HEs/oHJnS4yE2fdBTib0/xya9AZHT7Cygx4TYedXsPljiNgBI1ZoH/YnVkKrQeDbA7KSwe6mbtKHF0FuJjz6Cxj0sP8X7aolPQECB8HptRD6BIxeDxZ5N1hOrNTO63NX5b6+tHjY/AGE/A/szdDxIjsd9Nm3vgeVzJQG7onAUpUglHzzdkaQlJ7D6nE9aN3QGSEEMzeHM23dac7HptK2oQsudmUrNa7cwc78rTVoP78NvNoWXqezhHv+A037wJz+sP0LuHYcYk/B/p/B0lZLCs9sKNwuEb4J6reFOn7a8wc+hF7vQvIlcPOHsIXwx4vaz90TwKk+LBmpbTvlevlfy5XDsOJFaBAE57dCyCRIuqglKycvuO+NW/dJOA/6XPBoZvp5rh6DxAhIvQq7voMG7eHRn8sftwlMuQ3lDKwTQiQAocAyKeU1s0alVFvp2bmsOHSJ3i09aeN9o1THE118+HrTWS5fz+SJrmpyHqUEUkLsae3b/4G5kJkETg1uTRQF1W8DbR+DfT9pzwfMABtnOLIYzq6Hc5tvJIuMRIjeC93HFz6GpbWWKADaDoMrR+DAHDgSWnmva9loiA+HmONaw/ofL95Yv38O9HhVS4CgXfHoc+D7uyEnHTqMgtQYsNBB+/8D5wbg1e7Wc/wzVbvFls/VBzqOqpzXUAJTbkO9B7wnhGgLDAW2CiGipZS9zR6dUq2kZuXy4m8HSEzP5um7/Qqtq+NgzZAO3izae5HegcVXiVXuYNnpsOY1OLMO0uNAWIB9XkmWkhJFvk7PwIlV4Hc3BD0JljbQ5lGYeRdE79O2SYuHhY+BNEDLh4o/loUF9PtE+6Z/cJ7WiH7tmLYuNaZwW8alg+DW+MZtnsRIsHYAh7pwYB7smgndXgLH+lqiyDfoey0Z7PwGvDtp57kSpj3eMxs2ToGGHbREAXBytZYgkqK0NhqdDTw+H5r3vXHMdW/D7u+gw0jt/XDw0G6d6czfU7DUaVWNGwpRH20A3TDASUppwv/u7aOmVTWvi/HpPDt/H+di0/h4SBse79Tolm0S0rLZdjZWVUhVbnXpAKybDBd3QpvHwO8eCAiBq0e0toPOz0H/cs5vtuplLYk8uUz7Jp90UWuraDmgbMc5txl+HaQ9DnpS67YrBHzqp93SGr4Itnys3cJyb6rd2lo4FGyctKsjYaF9cPf7FLZ+BqPXgU1em11aHEwLgJDJkJEEu77Vtk29Bt3GacfKF38OLu6CPbO096f7yxDyDlw7Cj+GQOdn4cHpWmyVwNRpVU2Zg/tFtCsKD7Q5JxZLKU+UuFMVUMnCfE5cTuaJn3YjJcx8ooMq0KeUjUEP05tpVxOBA7Vvy8Z1Bjg0H1o+XP7G31NrIHS49tjGRftQ9yvHmOGUa/B5XruB0Gnx+N4NJ/64sY3OGlr0h+MrtOceLeGZ9RCxDXZ8pX3jb/9/RR9/ZletrQW05Nj3Y0i+DHWKGayakwHrJmltMw3aa1dL16NhfBjYVt7A0wrPwV2AL/CKlDKs4mEpNdEvOy6gN0hWj+txyzzXilKqiO1aouj+Mtz3ZuF1FhbQ8amKHb/Fg/D8v9otoEZdwaWcXbUd62nf8pv3A1sXWDn2RqLwaKEd+97XtDaCpg9o7RJdntc+uFv0135K0uYx7ZZVz7e1qwMhik8UoPUGG/AFNA6GVeMg8zoMW1ipiaIsir2yEEI4SymThRBFpnsTZsq7rdSVhXnoDZLOH27k3qZ1+XJY+6oOR6mJVk/Q2gReOwvWNWgO8ex0+PMV7RZU93FVG0vyZa33k2/3Sj90ZVxZLAQGoM2WJyk8UZEpM+UptcDWMzEkpGWrRmulfKSEM+u19omalChAi3fI7KqOQuPcQPupQsUmCynlgLx//W9fOEply841YKUT5Sq1kZ6dy1u/H6WxhwO9S5gHW1GKFXMCUi5D0/urOhKlgkqtDSWE2GTKMqX6SUzL5q6PN/HI9zsJi0oC4Mr1DI5fvo4pveD2XkjgWnIW/xsQiK2VztzhKrVN/Dn46z/a4yaqp31NV+yVhRDCFrAH6goh6nDjNpQzULXXQ0qJohLSeXP5EXaeiwe0/7hBM3fQu6UnO8LjyMjRM6FXUybe34zkzBxC916kmacTwc0L18nZH5GIzkLQxU/NDaGUgZRaz6DNH2kjrAd9X+W3UJSKK6nN4nngFbTEcIAbySIZmGnmuJRyMhgkE0IPcfZaKjoLQe+W9fj88SC+2xzOkv1RNKvvRF0Ha2b9e44tp2M4euk6Bgk2efNDvLX8CA+0rs/ou/3ZF5FAqwbOONio0uA1kpSV1he/TOfMHzjW8iFtPICTqhhcG5gyzuJlKeU3tymecrtTe0OlZOZwMSEda50FKw5dYuPJa5y5lsr0x9pxf6AnNpYWxltIUkqEEFyMT2f4j7tp6GpH18ZuNKpjz5u/H8HWUofeIDHI/B94/r7GhWaoU2oAg14b6GbjDI/cxgLRBRNF1xeg7ye3P1kpZVZp4yyklN8IIVoDgYBtgeXzi99LuV2enrOP/ZGJ2FpZkKOXdPFz48PBfgxp3/CWOajzG7l93O3Z8d+QQusOXkwkdF8Uj3fyZuL9zVi05yI2Vrpbynoo1ZzBABve0YrzgTb2wL0J3D1eq68EkHIVVrwAfabeWFYeGYmQnXZjXMPu7/MSxYvagDOVKGoVU6dVDUZLFmuAfsB2QCWLKrb5dAz7IxMBcLGz4o+xd+PlYleuY73apxnnY9MY2c0PLxc7Xu3TvDJDVW6HnAz44yU4/ju0HarNDRF7GhLOaYPLQiaDZ2ttkNz5zdokQyP+gICe5TvfqvFwcpXWLdazFRxaoD1WiaJWMuU21FGgHXBIStlOCOEJ/CSlLKFK1+13J9yGik5MZ+qfJzhzLRUh4HJSBj5u9ix67i4sLSxwsVdlwe9Y+hyYOwCidkPv97Sy25lJWgNzdjr8OUErVFeQW4CWSNoNB78e2lVGwgWtJEdpH/ZSwodekJuh7Rd7Bgy58OxGrTieUmNUZrmPDCmlQQiRK4RwBmJQA/KqxBfrz7D1TCy9WnoigI4+dXjl/ma4O9pUdWhKVbtyREsU/T6Drs9ry+zy5jy3soPHf4Vjy7XS1jEntNIVI1dqU4zu+EorF57vqTVabaW0OLBzuzE5UEEJ57VE8dBXWrkOfa42CZE5JvdRqgVTksV+IYQr2lSqB4BUYK9Zo1KKtD8ykeBm9Zj5hPrmptzkyiHt32Z9i14vhFbOu9kDWqXU+97Ukkivd7Q6RQnnYcfXcHYdbJ+hJZCz6yCgFyRe0OZakAYtIWSlaIkHwLuz9q/OUiWKWs6UBu6X8h7+IIT4G3CWUh4xb1jKzWJSMrmYkM6Iu0ooPKbcuS6HaVcSrqVMPGXjBE+vKbwsv5SEXw9Y+rTW5uHgod1eOpc3/nbju9q/FpZaLythAXWbawX2lDtCSYPyiv36KoToIKU8aJ6QlKIciNAasjv61aniSJRqJyMJovaAV1DFG5Yf+FBrs2jWF1KuaA3mfaZqYyXs3LSrkVraeJ0bF4eFvT0W9jWshtVtUtKVxeclrJNASAnrlUq2/sQ1XOysaN3ApfSNFQD0yckIW1ssrK2rOhTzWv4MxJ2BLmMqfiznBtAqbwIgN38Yvbbix6zmZE4OV6ZM4fry37ENDESfnIxtyxY4P/QQjsHBZvv9kVKSefQouXFx2DRrhpWXF0JXfcvqlFRIsJz96ZTKlpmjZ8OJa/Rv44W1ZanlvO44+YMNC7q+ejWX//sWOhcXfH/7FZvGtbRPhsEAkbug02jo8lxVR1PjGNLTiX7lFdL+3YbO3Z3MEyewcHYmPSyMlA0bsaxXD8fgYFyHDMYuKKhSz50wZy4xn31mfG5Zvz6ujzyC62OPYlW/+o16N2WcxciilqtBeZUnLSuX8JhUzsakcjEhneFdGhUaL7HldAypWbkMaOdVhVFWT5knTxI9dhxeH32Ew11dyTp3jriZM0nZvAWr+vUxZGQQMWw4LgMG4DJkCLatAhFCIA0Gsk6fJn3fPrIjIvAYPx6dq2tVv5yyS4qAnDRtJjWlTPRJSUS98CIZR45Q//33cB0yhGsffYRT797Yd+lC2q5dxH77LUlLlpC8Zg0O9/TA2rsR1n5+WPv6kBufQMq6deRcuULdcWNxvNv02fnSdu4k9ptvcLjvXuo+9xxZ58+Tsn4Dcd99R/zPP+O/dAlWPj5gMGBhV76xU5XNlHEWBUt92AK9gINSykfNGVhZ1dRxFrO2nuPTv09hKPDfMLh9Q2YMvfEtZuzCg+w+F8+et3thqVNXFvmkXs+FwUPIOnMGa19fHO69l8SFC7Gws8MxOJh6E19Bn5pG/KxZpGzciMzOxtrPDyufRuREXiQ7MtJ4LOeHH6JhgW95NcbJ1bD4/+C5f6Bhx6qOploq6spTGgxceORRssPDafD5dJz79Cl2/5zLl7n89iRyr1wh+/JlyMkxrtO5umLh6EhOdDTO/fvjOeltLN2K7xWWcy2Ga598TMrav7Hy9cH3l1+wanhjzvrsiAgihg5DV7cuuXFxGFJTsWnWDLu2bXHq3QvHe+6pwDtRtMos9/HyTQd2AX6tQGxKngORiXy89hR9Aj0Z0sGbpp6O/Lorkl93R9LJrw7bz8Zx+Xomxy9dZ2jnRnd0ooj7YRaWdd1x6t2bxCVLsaxbl5yrV8g6cwabpk3JOnuW7F9/xfXxx/GYMB5Ld3cArICGX3yO/vp1kteuJXXLVrKjoxD29nh9/DEOd3UlaelS4r77Hpf+/XG8776qfaFlde04ILS5oO9gUq/HkJJS5NXhxREjEdZWNPjsM3ITEkjfvQf7rl3JOnkSz3f+V2KiALBq0ADfuXO08+TmknPpEtmRkVg4OWHXujVSSuJn/0j8rFlkR0TgO38ehsxMss6GY9eubaErg0sTJ5J5/Dh1x7+M+zPPYGFTeIyUtZ8fXh99yLUPP8KmcWPsu3Yh88gRkv/6i6QlS/BdsAD7DoWvIvUpKeicnMr71pms1CuLW3YQwgo4IqWsVr+dNfHK4vP1p/luyznC3rkfJ1tt9HVMciZ9v9pGQlo29ZxsaF7fiYaudrwU3AQf9zuzl4YhK4vT7Yq+X2zbqhU+8+ZxfdVKHLp1w8a/7HN1GbKzuTBkCIb0dALWrr3lD7g4UkrStu/Ark1rdK6uSIOB2G++waV/f2yaNClzHOWycJg2CnvcvttzviqWcfQoabt34/700wjLG991Y7/5lriZM7Hy9saufXvsO3XCdfAgsqOiON9/AACW9ephYWdHdmQkDt27kbZzFwF/r8Xaz69SYkv5ZzPRY8eic3PDqmFDMo8cQVhZYdexI/VenYiluzvhvXrj8eqr1B1TtvYlQ1oa5x56CJmZhfszo3EZMgTLOnWQUhLx+FBsGvvT4NNPyxV3pV1ZCCFWo/V+Am2ypEBgSbmiUoxSMnPYeiaWNg1djIkCoJ6zLT+O7MjCPVFM7t+SOg61vCePCTIOH9YeCAFSUu/113Hq3Yvs6GhsmjZF5+iA2xNPlPv4FtbW1H/7bS6Ofoak0FDcRo0yab/UzVuIfuklhI0Nzv36Yd+5M/Hf/4A+Lg6vqVNNOkbyuvXE/fADXu+/h12bMhb1kxKi9xY/EK8ISX/8gT4hEdfHHr0t30YrU/r+/UT+3wgAsk6eRNjbk3PpEvUmTCD9wAEsG3hh26oV6bt3k7x6NXGzfiD38hUAvH/4nmsffkR2ZCQ6V1fSdu4CwMq38sYtOYX0xHfBAi6OHk3mkSM4P9gPS8/6JK9dS+TIUTj36weA8wMlX8kUxcLBAZ/Zs7ny7hRipk0n/sefcAwOxrKuO5lHj+L6mPlbBUwZwT29wONcIFJKGW2meO4I6dm53DdtCwlp2bwYHHDL+o6+bnT0VaNhIe/b+7btIATNdu/CkJFh7CliXYl/6PbduuFw991cm/45Vo0a4RQSQm5CAjnR0di1bVvkPslr16JzccGpX1+SV63m+h9/AJD677Yi75MX5fqKFWSdPMnFp0fjt2ghNk2blrzDrplg7aCV2Eg4D+nxN0ZRlyI3Lo4r/30LAENGOh5jx966TWIilnVuz1geQ3o6KRs2YNexIzI7h8yjR8g8dRrb1q3QJyTiPKC/MRap1xMz/XMsPT2xbd2a5DVr0bm7Y0hLI37uPLJOnsSpTx+8pr6v3Rb64QdiZ36HpacnNgGNcQoOxr59e9IPHsTax4fz/Qdg16ljuaYbLol9h/bUGfo4CfN/pe7LL2Pj74/7M6M5138A11eswL5z53L/3to0aYLfgt/IPHWKuO9/IPXff9EnJGDVoAGugwZV6usoiiltFlsB8upCWeY9dpNSJpg5tlrl1NVkRv68l8AGzrjYWZGQlk3rhs480aWUEbd3KGkwkPjbbyQtXUrW2XDsO3dG5+KCzsU840yEEDSc8QUXn3mW6Amv4D3jC+J+/JHMw0fwmTcPh65dCm2fuHQpKRs34tz/QbymTKHO8Ce4MHAgALnXrpF57NgtVwo5ly6RfvAgzv37IywstH72J05g16kj2ZGRRL3wIn5Ll6BzdEQU17d/3dvav4GDYM8s7XGjLkVve5PkNdqYCWFtTdq27bgOGYKV140ednHff+/ruvAAACAASURBVE/szO/wX7IY28BAk45ZXvrUNCKHDyPrbDg6V1f0Sdq0v1hYaN2BgZzoKJz69iV9335SN20i4/BhvD76CJdBAzGkp6NzdOTq+++TuFCra2XTUhtNLoSg7osv4vb00wgbG9DrAbTE3lMbEdB4zRp0zua5svJ49VWcBzxkvCVqWbcuHi+/TOyXX1L/3XcqfHzbFi3w/upLpJTkREVhYWdX/O9LJTKlN9QYYCqQARjQZsyTUspq1XG9urdZfLXxLF9uOoOfuwMX4tJo7+PK7y92r/RvNrVF0oo/uPLWW9i1a4fLkCE4938QnaOj2c+rT0nh4rPPknn8BOTmAmDbri3eX3+DpVsdhJUVqVu3EvX8C9i2bUvD6dOw9tESftruPVjY2hD10lh0Li40nPEFti20DzBDZiaRTzxJ5okTOPXtS4OPPyL3/9s77/Coiq8Bv5PdbHpCOiQkhN6kd6R36UgVBUUsqKAU9SeoCCoKogiflSqCFFEUUJFeBKmhEwgQQkgCJCGF9LLZne+Pu4SElhATSGDe59lnd+fOzJ1zs7nnzpw558TFc75TJ7zffRe7+vW4+MwwrOzsMKenU3bqFGRWFmX697/hqJWRiPzUHyQIW0fM6SmY/Lohu36GMBjy3PjTjhwh6Y8/cOrSFYfmzcg4e5bw50ei9/LEsXUb4uZqisaxXTs8x76BztmZ8127IY1G7Js0wWP0aOzq1imWbZvmrCwix4whddduXPr1JXH1bzh26IDX+HFY+/gQ9cknJP66Ok8bQ5XKuD/3HGUG5F1uST96lLAhTwFQYfnyW4y/JQlzZmaB7WH3k4LaLAqiLM4BLaSUsYUYRDdgDqBDC2s+/abjNmh5MRoBccBgKWWYEKIzMB0wAFnAW1LKbXc7V0lXFkPn7yMhzcjfb7QmIj4NJ1s9ZeyVPeJ2pJ84QeQbb6ArU4aKq1ffd4VqSkkh4oUXST92DMf27UnZpv30rH18cBv5PHHz5qNzdibg119u+8+feuAAkWNex5yUhEvvXjh27MiViZMwp6bi3L07SX//jU2VymSeCwEg4JdfsKvzGEkbNnBp7Lg8fTn37InvtMlaVFm9DeHDBmLOssK9nT/Re80Yo+PAZMLKxYXq+/dhzswkcc1aoj/+GGk0Yu3ri8/Mz4h8RbOt+P+wCHNaGmEDB+HQujXpx45hTkrC2tcX46VLuD37LPE//qid3Noa31lf4Ny5c5FdW5mVReQbY0nZvp2yU6fiOngQ6SeDsKlWNY+ndPzSn4ieNg2HNq3xmT79rttRE//6i5StWyn36acl8mZcHIQlhqGz0lHWoSzWVv8tNUFRKosNwJNSyrR7HIAOOAt0BiKBg8BTUspTueq8CtSVUo4SQgwB+kkpBwshGgDRUsrLlix9G6WUvrc5TQ4lWVlkZZupO3UjQ5r4M6V37Qc9nBJB+skgMk6ewHXIkDzl5rQ0zrVrjzAYKD9nNvaNHozvgDk9nayLFzFeukTka6MBsKlRg8zgYAAqrFiOfYM7P8WaEhOJW7CA+CVLkZmZWPv4UO7jj3Bo2ZLk7du5/OZb2NaujetTQ3Dq1i1HIWYnJBA+4nkyg4OxcnbCnJRM+Q6ZGGwSScxsQty2G74hhsqVMSUlYrqqPceVeWoIyZs2Y4qLw65+fVyHPcPlCW8CYO3ri//iHzD4+WnjS0lB5+iIKTGRyLFjSdu7D325clTdvg1TYiJpR45wZeIkHFq3KpD/iTkrS1t6a9Dgtso9Zs4crOzsST9+jJQtWyn7wWRcn3rqztcvJYX4RYtwe+45dM7O+Z7/YcZoMvL98e8JTwrnszafsSJ4BZ8e+BQAndBRx6MOoxuMplm5ZoXqvyjzWUwE9ggh9gOZ1wullK/n064pECKlDLUMaCXQBziVq04fYIrl86/A10IIIaU8kqtOEGArhLCRUmZSCjkeeY0Mo5nmlR5uo3Xm+fMkb92G+8jn7xrjJvvqVSJefhlTXBx6b++cdWTQnhLNSUlUWPbTA1MUAFZ2dtjWqIHe0zOnrOLvv5G2dy+mpKS7KgrQ1se9JkzAdehQEpYvx7lHj5wlKaf27am6dw/C2vqWG6ve1RWnTp3ICg2l0jA3In6KJ+qgI7YukBKpKQprHx/cnnsW16eeIjMkhPTjJ4ieNo1rK1bi2K4dbs8Ox755c0Bbv08/GYTb8GF5QkhcX9LTubjgOWYMF/fuy7Gx6FxccGrXjsTGjUla9wfpR47i3KM7SPAc+8YtYzZnZBA5egypu3fjPWkibsPzBn0wpaQQ9933Od+93333rori+vg8X8/vFvPwcyHxAu/seodTcdpts1vFbsw8OJPWvq3pXKEzEckR/BH6B2tC1hRaWRSUgswsDqClUT2BZrMAQEr5Yz7tBgDdpJQvWL4PA5pJKUfnqnPSUifS8v28pU7sTf2MklJ2us05XgJeAvD39290MZdHbknim+0hzNx4hsPvd8btId0Kmx0by7lWmnep3/x5d/Q0zY6PJ/zZ58iKjETv6Un21av4fj4Tp44dkVJy4cn+YDJRce2aEmPPiRzzOg4tW+R7gysqzFlZZF+OxLCkKeneAwmbvVPbJmuh6q5/8igx0GZqOkeHQvkMSClJ3rgJ+6ZN8iz3xC1cRMzMmXnqek4Yj8eLN3wEzGlpRLz6Gmn792vOkRcuEPDTUjKCz2BOS8MQUIH0o8dybCSuw4dRdtKkex7jw0p0ajRnEs7QyrcVVsKK89fOczr+NN0rdufP0D/5eN/HGHQG3m7yNlP3TCXLnAXA2r5rqeSimY0zTZmkG9MpY1u4cDVFObPIllKOL8wYblN2s2a6ax0hRG1gBnDbjclSynnAPNCWoQoxxvvCvtA4qnk7PlSKQmZnk7J7N5mnT5MRrMVYQq+H7GyurVqVR1mkHT5CWmAgLn16E/HSy2RFROD3/fcYKgYQ/twIYufNw6ljR9IPHybz9GnKTplSYhQFQPmv/u++ns/KYMBgkwxmI3aPd8I11o+EpTeCJtysKADsHiv88qYQAuduXW8pt2+szexsatYEAQbf8lyd9SU2lavg1KE90mQicvQY0g4cwGf6pzi2a8eFJ/sT/tLLmBMT8/Sl9/SkyratCOuHN/Xv1otbSctOo71fe47HHqelT0v+OP8Hsw7NIsA5gGmtpuHj6JOnzVdHvmLt+bXU96yPzkrHoehDACw/vZwTsSdoUrYJ01tPx8vei/1X9rPu/DqquVbLURQANjobbHTFb6spiLLYbnmC/4O8y1D5bZ2NBPxyfS8PXL5DnUghhB5wAeIBhBDlgd+B4VLK8wUYZ4nEaDJz6GIC/RuWf9BDKVKipk7l2i+/AmDt7499kya4v/QiyRs2ErdwYY4jXcbZs0R/8ikyPZ2rs2YhbGzw++5bHJprU2aX3r24+n9fEfPlbOKXLkVXpgwuvXo+MLlKDFcsjojl6uM1oQf29evi2KIR0rr4d4Rdx65ePSr99SeGSpUQQmBOT+fiM8O4/OabBPy8kqRNm0jds4eyH07FxbJtuPzXXxH29DMYKlfG/4dFGC9dIvvqVWyqVH2oFcWSoCXMDNRmYXqhJ1tm09CrIYdjDvOY+2OciT/DK1teYckTS3CxubH9++jVowQ4BxCeHI6d3o5xjcZxJeUKK8+sxMvOi9ntZ+Ns0Gw2U1pOoYVPC6qWyccXp5goyDLUhdsU57t11nLzP4sWePASmoF7qJQyKFed14A6uQzcT0opB1nSuO4EPpRSrr5N97dQUg3cR8IT6PftHr4e2oCedX3yb1DCybp4kayISCJeeAG3Z4fjMeZ1dI4OOcezExI436kz5tTUnDK9lxceY0ZjDA/HsX177BveyKuVcfo0F/o9CYBjp454v/12zlbUR5bUOPj5aYg6Ce+E3z4H9gPCGBXFhQEDkWlpmNPScO7dC58ZM/LMBLPCw7FycMiJz/UwYpZm9l3eR6UylTgSc4S3/3mbjv4dSTWmsu/KPgCshBWj6o3ixTovciTmCC9vfpmGXg2Z32U+QggSMhJo83MbxjYcy/OPPQ+Qcx0jkiIw6Ax4O3gXuyxFGUjw3oPtaO2yhRCjgY1oW2cXSSmDhBAfAoFSynXAQmCpECIEbUZxfWvMaKAK8L4Q4n1LWRcpZUxhxvIg2X9Bm4A1rVi6jdum5GRiZs3i2sqfQUqsnJ3xHDcOK1vbPPX0rq74zv6SjKBT2FSrik3Vqlj7+iLucMOzqVEDr3f+h2316ji0aHE/RCm5pMXD8VUQfRIiD0KnqSVKUQBYly2L37ffEDVtGroyZSg7+YNblgwfdmVvMpsYt2Mc2yO2YyWssMKKRt6NmNFmBkdijhAYFcg3Hb/Bx9GHAJcAAJqUbcL/mvyPj/d/zMKTC7HT23EsRps91vOsd8s19HP2u/m0D5yCzCxKRT6LkjqzGPHDAS7Gp7FtQrsHPZRCIaUkad06Yj7/gmzLlsz0w4dx6dMHnxnT8+9AkT9SwrGVsOld4jMScDWbyQh4HLvn1uffVnFfuZRyiR+DfmRF8ApG1x9NpimTsKQwprSckrNclGZMw9761qCf2eZs+q3tR1hSGAB2ejtquddibue598XmcCeK0sCdO/BMTj4LNGc6xV3IMJrYGxrHoMYl7ykhP8yZmWA2k3bgAJf/9w62tWtT/ttvsa1Zg/jFi3PWqBVFwLaPCDz4NXO9/dhn5UCz9Az2iwi+ithBO792D3p0CjQlMWHHBILitFX0vlX68lLdl267EeN2igJAb6VnUddFXE69THnH8rjZupWojRz5ofJZFCP/hsSSYTTTqWbxrzsWBTI7m8Q//yR502ZS//0XmZWFlYMDwsaGgBXLc+LPuL/wwgMeaelESkl0WjRp2WkYTUYquVTCWmfN5xfW8GM5b9xsHXHKTGa/JcLGpN2T2DZwG7Z627t3/JCyM2Inn+z/hLqedWnh04JuAd3ueCMuTlafXc2ik4uISYthfKPxdPDvQAXnwgUD9LT3xNP+1t1spYGCzCxuJg14MOb4UkRwVBKzNp/F0UZPs1LijBc94zMSli7VcgEPHEjy5s1kR0dj37TpfQlU9jAQFBuEn7NfzpJEbuafmM9XR24kniwnbGjt05LV+ix62Qfwfr9fmHVwJivP/kK78u3YEbmDOYfn4GrrSlJmEm392tKk7J0jzKZnp3Mw6iD/RP6Di40LYxqMuWPdkoqUksl7JtPatzVLTy0lLTuNQ9GH2BC2gT9D/8SgMzC6/mge83jsvownLDGMKXunAPB0zacZ8diI+3LekojKZ1HEGE1mPt90hgW7LuBiZ83nA+tio7+zN3NJIeviRRKWLsV16FC8338PIQQ21asR9f5krMvdlDw++hR4Vgerki/X/eRq2lWG/DUEaytrtg7ciqvtjVDfUkrWnV9HbffaDK81nOzgP/gzfDN/RGzFXsKEakOx09vxZLWBBMYc4b3m73Fx80V+Ov0TANZW1iw5tYTVvVdT1fXWZ7XY9Fj6r+tPfEY8AoFEMrj6YLzsvW6pezbhLEmZSTTwaoCuhP0Nd0TsYE3IGtaEaOHe32z8JsNrDeeLwC/48ZTmB3w4+jAzWs+gnV87ss3ZbI3YSnu/9gVa95dSkmXOKrCN4I/QPwB4sc6LPPfYc4UT6iFB5bMoQqSUjFl+hA1BUQxu7Mc7T9Qo+cmLki5DfCgZJxMAKDOgf846qkuvXmScOoX7yJE36sdfgO9aQPPXoNsnD2LEJZbAaG2DhdFs5MtDXzK15VTNP0GaWRG8gotJF/mgxQd0N3hD0BZ6p17FCGQKgWO/xwGo6V6T3/v8DsCP3X4kITOBcg7lyDJl0eXXLsw/Pp8PH/8Qg86AlbDixNUTBMUFEZMWQ3xGPHPaz6GsQ1kG/zmYHRE76FmpJyuCV+Bm64avoy9LTy9lR8QOAOp71qdPlT608m1FyLUQZhyYwedtP6e6W/X7et2SspL4IvALjsUcIzQxNM+xvlX6IoRgeO3h/HbuNwbXGMyuyF28vv116nvWp7xTef4M/ZPnaj/HhMYT8j3X9dnd7iG78/g73MzpuNPMOjSLfVf20dKnJa83VKFH7qgshBBVAO/r+Sxylbe2xGkqtY5yxcWW0zFsCIri7W7VebXdfUqrWUikyUTygg+JW7ICvY0RmyoBoNNhqHwjGZOVrS3lPvgAkqNvNIw6ob0fXPDoKItlA6HC49Bq7F2rBUYF4mDtQL8q/fjp9E/8E/kPDb0bohM6NoRtoFqZKnQ+vx8OvAiOZeGlnVjHhWB9dgOUuXW7qauta87sxE5vx+Dqg/kh6Af+Dvub6q7VmdRsEhN3TeRyqubr2sq3FR38OyClxN/Jn23h2zgdf5pfz/6a06fBysDYhmNxtHZkwckFTN07Nc85V51Zxfst3ud+8k/kP/x27jdalGtB14CutPBpwWtbX2NC4wk5N3Qvey92DdmFzkrHqHqj+P3c7yw8uZCjV4/iYO3A0lNLGVR9EH5Od99MsjhoMQALTy5kfKNbA1MYTUY+2vcRa0LW4GLjwhsN32BA1eLPQlcauNvMYjZwuyAu6ZZjvYplRKWY/9t6jgB3e15sXaJSfeQhKzKSS+PGYQw9gynViLDWk2HUkZ0ejsGnwo0Qz+nXYPsnkJ0Bh3+EF7ZB+UYQbfGpNGVqsxLnXI6GiZFgbQ+n1kBmCrQco6VCLenEnYfLR+DCTmgwHPxy2QWM6XBuk/Zq+TocWw6pV6FV3lDi6dnp7L60m/pe9RnfaDzVXKtxMOogh2MOcynlEv2r9ueDmKuI/fOg8fPQaQrYuoBPfahTsJvRwOoD+SHoBwASMhN4doOW/rVd+XbU8azDk1U150YhBB38O+TcGIfXGs6QGkO4mHQRPye/HOPsoOqDCE0MZc/lPVgJK/6J/IdNFzfxVpO37qtR/VzCOfRWer7p9E1OuO3dQ3bfslPo+pKZjc6GITWG0L9qf/Zc3oOfkx991vah+2/dae3bmg9afJDjzBaVGsWYbWNwsHbglXqvkJmtBaFYErSEVj6taFoub+KoVWdX8XvI7wyrNYxR9Ubd1vb0qHI3ZREgpTx+c6GUMlAIEVBsIyqlnIhM5MSlRD7qUxtr3YN3pMo4c5bkLZsx+Pkh9HoyQ0LIPHOK1H2BICSOHok4DWqPTd+JhPbpS0aCAafrD7dRJ+DnYZCQy3n/9FqLsjgJVnrNN2DvN9B1mnY87F9Y3D3vIJKvQNdPSrTCiPj3C1YF/h/PJiWx1tGB2LB1jCpTD5d274J/M02RXGdeW4iy/EtU7QretZBSsvfKXuYem8uV1Ct80OIDrHXW9Kvaj35V+wEQlxqD69GfEcfmQIvRN67ZPeLn5MegaoNwMDgwqu4oFpxYQFBcEDPbzrzl5p5bWbxU9yVcbFxueeoWQlC5TGUql9Fmk9VcqzFy40hGbBhBOcdymKWZJ6s+SZvybQo13oJyNuGstjMsV16GgmwptdZZ09avLQDNyjVj/5X9HIg6wIA/BvDx4x/T1q8tH+79kIjkCOz0drywSdvF90mrT5h/Yj5v/fMWbzV5Cw87D9xs3TCajXx/7HualW3GW43fKlXbWu8Hd1MWd3u0KPr0WaWclQfDsbW2onf9u6bduC9knDnLxaefxpySkqfc2jEbp4plcO/RCJvL62D892Btq0ULPXcOe89MOLoC/hwHdmXgic9gw0SQJjj+C2QmQ9huqNFTm0Hs/x6yM7Wn7KDf8w6iVl/Y9y2YjNB6AjiXo6Sx+8xvvH12EcllnFlc5sYT5HpTKG/+3JeeHg0QjrkMxMlXoPvnsPFdMrd8wMjMs8TYOXMl6xrutu5MaTmFlr4t857EbMZ912zY9w34NdeuxX8g9xLR3dbR63rUxcngRCf/Tnddm89Nk7JNeK/5eyw9tZQLiRdIykpia/hWOvl3YkabGRh0xWN/O5twlqZlC5Ya9k581uYzQq+F4m7nztv/vM3obaOZ1GwSgdGB9KvSjzcavsFPp3/iYNRB2vu1p7ZHbYb/PZyJuybm6cfFxoVJzScpRXEb7ujBLYRYAWyTUs6/qXwkWuiNwfdhfAXmQXpwp2Vl03TaVrrU9mbWoPoPZAyg5a1OO3CAy2+Oh6xUKrzRDlPsVcSFLRi8nLAy6CA1Fhw8oXxjGLIMANO1a5j/nIh1yHKto4DWMGAROHpp9c9vh3WjweAIdq7aEkqFlrBlChxdBsIKdAao2BaajNSevh8fC5veg71fazOR/gugdr884zWajSC1J8T7zargn/l4/8dUzcrmxRaTmHFqEWZp5vO2nzM78AuOxwXR1AhPJsTiYjbTfNAvpLhW4N/4k5iPr8L1zAZeKeuFhxneaP0R3St2z3szlRLOboRtH2mzsSYvQI8v7quMWaYs9FZ6rEThZroZ2RnMOTyHn07/xHedvqOVb6v/NJ6g2CACXAJwsL4RS+xaxjVa/9yacY3G5cRH+q9kmjIZu30suy/tBmB2u9l0rNDxlnppxjSiUqOIy4gjPiOepKwkmpVthr/zwx2u5Gb+c6Y8IYQ3WtTXLOCQpbgxWqrTflLKqCIaa5HwIJXFgl2hfPzXaX4Z1YImAcXrU5EWGIjxShTO3Z/Ik2AoYeXPxC2YjzHyEjpbiX/bq9h624LQwWP9tBt82G74+RmtQZ9vocHTNzoOXKTNKADej4WC3sATLsLuWXBkGQxYCLVyeXZLCZcOw8aJmq3jrfNgfWPCOnb7WBIyEljcbXHBnuTMJm2JzLUCXNgFwX9CpfZQ/0aeCSklOyJ2UMezDh52HpjMplu2hxrD99Fu28vUyEjjq3pjsW/xGunZ6WRkZ+Bq64pZmvn17K/MPjSLZKMWENHZ4EyKMQWzzEnpgg7BnrBw7FuMgeav3LDfXAuH1S9AxH5wrQgd3oPaT5a4OE8FISM7g8dXPM6QGkN4q8lbAKwJWcOPQT/yRdsvcLFxYc/lPey/sp+otCjGNhx7iw9ESlYK6y+s56N9H9G5QmdmtZsFaH+rLeFbGL9jPIu7LaaRd9Elu0rJSqHFCi3WWH47nx51ijKtanvg+l8/KL9c2A+KB6UsNp+KZtRPh3i8igc/jmhyx5vetTVrSPhpGZ6vj8GxTeHWgKWUnO/aDWN4ODbVquH11ls4tHqc+EWLiJn5OXYeWbhWScUpQGL14t/g2zBvB4mR8GVtQMCb58Axlydp+D5Y1BWqPQFDV9774MzmO98Mz26C5QPhmdVQRcthFZ8RT4dVHTBJE/O7zKd5ueZ522Qmg7XDjT5T42Bp3xs2A9DkQELlDvDEZ0j3Knx56Et+CPqB7hW709S9DlMCZ2Crs8XR4Iijtfa6EnuKOGFmtvSk4/Atdxx3QkYCkT90Ica+DFsqNcbPyY/Wvq05dvUYMw7OoIKTH3+avODUWm12VbMXpCdA6A4wOEGXD6HBsIIr3hLKC5teIC49jt/7/M6K4BV8sl/bBedm60ZKVgpZ5ixcbFzQCz3p2en83f/vnGMnYk8wbf80LiZpicns9HZ82upTvj/+PVmmLCqXqcyey3vYNWTXf84lfTPnEs4RFBdE3yp9i7Tfh40iUxalhQehLPaHxjFs0QFqlnNm+QvNcLDRTECp+w+g9/LEEBCAEILM0FBCu/dA2Nsj09PxGP0arkOHonNyQugL7kSfERzMhb79cOnTm7TDRzBGRKAvW5bsqCic/NLxHdka0fhZKFsvryK4jpTwRXUoUwFe2Jz3mNkMB+dD3UHaUtM9cuLqCT7Z/wn9qvZjUPVBeQ8a02FGRe1m2udr0Nuw6swqPtr3EQ7WDtTxqMP8LpbVzqw0uBoMP/YCp3LgXkW72V45BslR0HmqthupYhvtBv1jL0zAkTp92OhbnZVnVuKOnjQrgbvJhN6YSbvaQ0nGTIoxhZT0eP6NPgjAwSF7sLVxurtgZpN2npseAlafXU11t+raU3RCGOyfB4eXgMEeUqKh73dQf+g9X8eSyLLTy5h+YDr9q/Zn9bnVtPNrx/Baw1lyagmedp4MqDaAGm41CEsMo+/avlR3q45e6AmKC0IicbR25ONWH5NmTGPSbm2DpZ+TH1GpURjNRjr4dWBOhzkPWMpHF6Usipmgy4kMmbsPL2cbfhnVMicLXmZICKE9tV3Fep9yuPTshc7FhZiZM6m0/i/i5s4lce06AFyffpqy779XoPPFzp/P1S+06XvVf3dj5eRE0tp1pPyzHWsHM17WyxEj1kGltnfvKGy3pgy8C59Z7WZOxp7kta2vEZ+hhWPf1H8T5RxvMmivfY1VIWsw2rnRp9kEXrqykXRTOr0q9+bLQ18ys+1MulTowm8renE15jgvX0vCyrMm6PSakdzRSzOkV+5wo08pYf/3LDs2l+m2JgCeTUyhfWoqz/loWyffj41nUKdZUM9iYju8hJC/x5PU7zsa1hpYZNcA0BSuEJBxrVAKt6SSkpVC5187k2JMoVtANz5p/ckdZwFv7XyLDWEbCHAOoHvF7tTzrEcdzzo4GZzIyM7g0wOf0sCrAT0r9eRIzBG2XNxCr8q97lv4DsWtKGVRzPT5ejfRSZn89mpLfMrc2Bx27fc1XJk4EY/XXiPj1ClStm8HvR6Dnx+V/16vhfxev57oDz/ClJZGlQ1/Y+179x1USZs3c2nM6zi0bo3z4/UpU0NoyzQRByAk1wxh4iWwuX+Z1ADWhqzlw70f4mHnwah6o5i8ZzJfdfgqJ1rqP5H/8OHeD5nZegbPb3qebGnGzmwm3cqKtzP09Ht2BwP/GkJkSiR+Tn5EJEcA8KJvR17vNDvf8xvNRrqv6khSehwzY2JpXX0AouFw/lj3PIcdnXnz4mkcavfXDOxCwPLBWriSscdL9JbeksaakDWEJ4XzWv3X7hoiJNucTWJmYqmLqPooU5QhyhU3IaUkJCaFQU388igKgIxTpxD29ni8+gpCpyPhl1+ImjIVx3btAG3/uEuPHtg3bEhI5y7EL/0JqSrwmAAAFpVJREFU73f+d8dzpe4/QPQnn2JTrRp+M6ci5rWCsFjtoK2L9rS9+0vwbXRfFYXRbOSLwC9YdnoZTcs25fO2n2PQGZi8ZzJn4s/kKIsNFzYQnRbN8I3PAfBGg9c5f3EHZ2KO0js6DMfz21kbGsIW3+qstDJgyMrC27UqK2L282xmYr6GyTPxZ4jKTGBmiym08W4CrgEA9BodpHmNrnlV27EVsR+qP6Ht7GoyUimKe6Sg6/56Kz3udg9vhrxHGaUsCkFiupHULBO+NymKmNmzSVi6FLt69XJ2KrkOHIhjq1bo3PLukrIuVw7nLp259ttveIwenZOa1JSUROy332FXtw4Jq34hbd8+9F5elJs0DrFiAGQmwYvboWxdbYkGoPWbYDYWv+C5mHd8HstOL+OZms8wofEE9FbaWMo7lufro1+TLbMZVmsYp+JO5Wk3sPogXOq+qNkmPq8KvzyLAeh+Lo7uVnowZXK01ScMOzCFVitb8UXbL+gS0AWA4Phg/J3884Spvj4TqexdP0dR5KH7TG2bb/B6OLxU8zyv2btYrolC8TBT+vbyPQBi584jdv58pFnbNnnpWjpAHmVhTk8n7vu5ABiq5o0LZV2u3I0wGrlwe/ZZzMnJXHp9DOlHjyKl5NovvxC/eDGXxk8g89w5vCe+Q+VNG7HLOqjt1x+yXNvlpMul520c7+sa+bWMaywJWkLnCp35X9P/5SgK0HbIAHx/7Hu6/9ad84nnebX+qznHc2YKBntoqIWrwNlXM7g7+4CdG/Wq9mJi04m427ozde9UYtJiOBR9iIF/DOT/jvxfnrGEJ4UDUN6p/O0Ha3CABs/AU8vh7VB4ZQ9UeMTTtyoUhUDNLPLBnJFB7NdfI41G0gMP4TPzMy4laMoi9xJUWqDmiuI28vkCJweyq1ePch99SNSHHxE25Cmsy5fHnJmBoUIFvCa+g0Pz5jdyXEcGgkc1qNq5aAUsBD8E/UB6djqv1nv1lmNjG40lMCqQtn5tmXN4Dnsu76GVTys6+HXI46MAQJePtQB6PvW1ZbRX90JGEkJvYGjNobT0acnAPwYy+d/JXEq5BMCRmCN5uohIjsDLzgs7fQGCChjsi9Swr1A8SihlkQ/px44jjUace/QgaeNGwgYOIuEFLUSAr6t2gzJnZHBt1SqEwYDn6NFY2RU8GkqZAQNw6tqV5M1bSPrrL1L37sX77bdxstg4AG3XT+RBqNatKEUrFLHpsawIXsETFZ+giuutkXWblG2Sk6Bnbue5JN7N7mBlBc1H3fhubae9LAS4BDC+8ficff0+Dj6EXgvFaDbm7MaJSI6486xCoVAUGWoZKh/SDhwAKyvKfjCZCot/wJSSQo1p46mQEY+ryCbuh8WEdO5M8ubNuI18/p4UBQBZqejiT1DmyX74L1xAjWNHcel1U0DfhAuQFqeF6CgmIpIjeHr90wxbP4wz8WfuWG/hiYVkmjIZVW/UHevk5r96zg6uPpgOfh1o5N2IcY3GkWHKYFPYJq7v4otMjsw3LLVCofjvqJlFPqT++y+2tWqhc3bGvnFjAn5eSVDPPnyw7wdCuy/U0o42b47nrFnYN7lzyss7svMz+Hc2vLgNfBshrG+zf/28xWm+wuP/TZg7YDKbmLBjAmcTzuJi48KIDSP4quNXNPJuhMls4njscQSCucfnsvvSbvpW6UtFl4rFMpabsRJWzG4/G7PUnOr8nPx4Z9c7zDk8h4beDYlJj6Gme837MhaF4lFGKYu7kB0bS/qxY3iMfi2nzFC+PF+1GcnY7fPA2pkKy37CvlEhY9qYsuHYCu3zrlk5gf1uIXg9uFXSbBb/ESklXx76kgxTBnU969LQqyEnY09yOv40M1rPoL5XfV7e/DIvbXqJL9t/yZqQNWy+qPlyXE8G80zNZ/7zOO4FIQQ6ocPFxoXf+/zOxrCNOa+GXg1v9RhXKBRFjlIWdyF5+3aQEqdOnXLKYpIz2GZfgfZTv+GpNtXRe3gUrnOzGda8ooWGKN9EC4oXfQq8a+WtF7oDLvwDzV4uEt+A0/GncxLorAhekVNewbkCXQO6orPSseSJJYzYMIIJOyaQYcrg6ZpPU8mlEt0rdsfRcH+d/m7GRmdD78q96V25N6nGVAxWhiKPKaRQKG5FKYvbILOySNq4iWsrf8a6gj821W480R+PSASgRsOa6D0KGWE2OkiLdXRilZZNrtV4+PIxLXpr/wWWQUjYPxc2TgKPqtDitbv3WUA2hm1EL/RsHbSVq2lXORxzmNj0WHpU6pHjmetq68oztZ5h6t6pOBmcGN9ofLHlMvgv5A51rVAoihelLG5CZmUROXYcKds0O4Hn2DdywhZkZZtZvCcMg86K2j73kG4xOxMu/qvZHEJ3aGHCTVnasdYTNB+JJs9rmefaTQT3yppX9tapUL0HPDkX8gt4VwA2XNjAstPLaOHTAjdbN9xs3ajuVv22dTtX6Mz0A9NvzdOgUCgeSZSyyEVuReHcsyeJR4+z3qchwwGzWfLmL8fYHRLLjP51sDcU8NJJCQs6ankYKraFi3vA3k1bfoIbznQtRmuRS/+do/kf/Dtb2yo7+Kciy4Mw78Q8/J39mdpyar51XWxcWNVrFWXtyxbJuRUKRelGKQsLUkouT3qXlG3b8H7/Pco8NZTHJ62HPVdp3TKVxf9eYN2xy/yvWw0GN/FHSsmbO9+kg38HelTqceeO40I0RQFwYSf4NNTyOvz6PDzW/0Y9p7Kap/HhJdpW2YxEaPt2kSmK2PRYziWcY2zDsXja3yZ8+W2o5FKpSM6tUChKP0pZWEjeuJGkP//E4/UxuD39NBtO3kgE2P7zHQC82Loio9pqN9Dg+GA2XdzEtoht+Dj60MCrwe07Dt+nvY/cAhH7oOFwLQDg8DW31n38DTi2UjNoN39V82ouBCaziWuZ1zgYfZCKzhWp7ladvZf3AtDcp3k+rRUKheJWlLKwkLxtG3pPTzxefhmAv09ewd3BgKeTDcFRyQxu7MfEJ2rm2C92XdoFgLe9N2O3j2Vlj5UExwez9PRShtUcRnv/9lqwvKPLwM5Nc6jzy8cPw7UCvH5EywaXO2/DPWA0GRm3Yxw7I3cCUM21Gl91+IpZh2ZR3rE8NVxrFKpfhULxaKOUhYXMc+cwVqzMpuCrGE1mtgfH0LV2WV5tX4XopAyaV8obdnln5E4ec3+Maa2mMXT9UMZsG0N4cjjp2enY6Gxor3PWlpoSwrT8ywXd9urkDU434j9FpUYx8+BMRjw2okAJYmYcnMHOyJ108OtAUFwQIddCGLVlFJnZmSzosuCuuQgUCoXiTqhwH0BWlpHUs+dZHW/Dy0sPMXr5EZIysulRtxwVPRxuURThSeEcv3qcThU6UalMJT5r8xlnE86Snp1OY+9GHLq8D+PCLkRiYkzDbrQ1h/Lt0W8paKKp6wH3guODefqvp9l0cRNfHfkq33ZrQ9by85mfGfHYCOZ0mMPnbT/HLM1EJEcwp8McKpepfO8XR6FQKFAzC4wmM5O/3cizJiM1mtfnzxGtsNFb4WCjvyWxEcCxq8cYv2M8AkHPSj0BaFO+DR81e4/osB1UjjjMWEM27Sv4kYgJQ2IIDbwb8N2x76jkUoluFW8NBphlyiIyOZILSRcIjApk9bnV9KrUi78u/IWjtSO9K/dm3fl1hCWGEeASkNMuISOBtSFraeTdCCEEH+37iKZlm/J6g9cBqONRh96Ve9Per31OcD+FQqEoDI+8sggMS+DS4eMA9OzTCjvfOwe+OxN/hlGbR6G30vNMrWfwdvCGlKtwYB59Ds6H9ATS3KvQyr0yZTxrUsejDq18W1HeqTzdf+vOmvNrblEWy08vZ+bBmWTL7JyyKmWqsOrsKup61mVW21norHSsv7Cen8/8TDXXalxOvczg6oNZeGIhP53+Kaedt703n7X5LCe/hM5Kx7RW04rycikUikeUYlUWQohuwBxAByyQUk6/6bgNsARoBMQBg6WUYZZjE4GRgAl4XUq5sTjG2KKyO27OMQgXF2yr3xR7yWwCyxr/pZRLvLLlFeyt7VnWfRll7Txh47twcIHmdFejB7QYjb1/c767jX2iW0A3Fgct5lzCOaq6ViUhI4HpB6bz94W/aenTkp6VexLgHIC/sz/OBmdSjal5PJS7VOiSRzEsPLEQK2FFR/+OdPTvyNX0q3Su0FmltFQoFMVCsSkLIYQO+AboDEQCB4UQ66SUufNsjgQSpJRVhBBDgBnAYCFELWAIUBvwAbYIIapJKU1FPU5TSgryn224DBiAMOTyVD7zNyfWvkBY58m0qjmIUZtHkWHKYEm3JZR1KAubJ8Per6HeUGg9XgvJcRcGVBvA7yG/M/SvoYxtNJZlp5cRnRrN8FrDGd1gNLZ62zz1bw5lMabBGIxmI+627gypMYQVwSvYHr6dF+u+SG13ldBHoVAUL6KgRtd77liIFsAUKWVXy/eJAFLKT3PV2Wips1cIoQeiAE/gndx1c9e70/kaN24sAwMD73mc6esXETFxOn4fvoFdnxvxl5bNb8p0Q3rOdxudDfPaf01Do0lLRLTlA81nonf+hufrXE27yqTdk9h3ZR96oWdB1wU08i5kxFqFQqEoAoQQh6SU+SbLKc5lKF8gItf3SKDZnepIKbOFEImAu6V8301tfYtjkHZdh1P19CyIXUdQbDs2hG1g14UNnDek0yEjG7/MNIJdvHkhy56Gi3rdiOlkZQ0dJt/TuTztPZnbeS6rzqzCzdZNKQqFQlFqKE5lcTvHgpunMXeqU5C2CCFeAl4C8Pf3v9fxaej0iBaj+GH/dGb9NQS90NE4LY0BVk4MHLoJm0NLtJwT9o7Q9CUtGKDeBgyO4FiwsBm5sRJWDKkxpHBjVSgUigdEcSqLSCB3vsvywOU71Im0LEO5APEFbIuUch4wD7RlqMIMMikriUkJB9jp5srjOhdmXgjGybuOFr/J3g3a/U97KRQKxSNMcTrlHQSqCiEqCiEMaAbrdTfVWQc8a/k8ANgmNSPKOmCIEMJGCFERqAocKI5BXki8wNGkUPRSMi48GCeP6jB8raYoFAqFQgEU48zCYoMYDWxE2zq7SEoZJIT4EAiUUq4DFgJLhRAhaDOKIZa2QUKIVcApIBt4rTh2QgHU86zHzsE7uTbDD/csIzQYBrb3kKtCoVAoHgGK1c9CSrkeWH9T2eRcnzOAgXdoOw24Lx5lOisd7np7yEyF6rd6WCsUCsWjziPvwZ3D0FVavgnXgAc9EoVCoShxKGVxHd+G2kuhUCgUt6CizioUCoUiX5SyUCgUCkW+KGWhUCgUinxRykKhUCgU+aKUhUKhUCjyRSkLhUKhUOSLUhYKhUKhyBelLBQKhUKRL8WW/Oh+I4S4ClwsYHUPILYYh3M/UbKUTJQsJRMly61UkFLmm2/hoVEW94IQIrAgmaFKA0qWkomSpWSiZCk8ahlKoVAoFPmilIVCoVAo8uVRVRbzHvQAihAlS8lEyVIyUbIUkkfSZqFQKBSKe+NRnVkoFAqF4h4oFcpCCOEnhNguhDgthAgSQrxhKXcTQmwWQpyzvLtayoUQ4v+EECFCiONCiIY39ecshLgkhPj6LuecaGl/RgjRNVf5IiFEjBDiZGmWRQhhK4Q4IIQ4ZhnH1NIqi6U8TAhxQghxVAgRWFplEUJUt8hw/ZUkhBhbGmWxlL8hhDhpGcc9yfEgZBFCuFvOl3JzHSHENCFEhBAi5V7lKGpZhBCmXL+RdXc557OWfs8JIZ79T7JIKUv8CygHNLR8dgLOArWAz4B3LOXvADMsn7sDfwMCaA7sv6m/OcBy4Os7nK8WcAywASoC5wGd5VgboCFwsjTLYunP0VLHGtgPNC+NsliOhQEeD8NvLFcdHRCFtg++1MkCPAacBOzREq1tAaqWcFkcgFbAqJvrWPorB6Q86N9YQcYAuAGhlndXy2fXwspSKmYWUsorUsrDls/JwGnAF+gD/Gip9iPQ1/K5D7BEauwDygghygEIIRoB3sCmu5yyD7BSSpkppbwAhABNLef/B4gv7bJY+rv+VGFted2TAaukyHIvYy5lsnQEzkspC+psWtJkqQnsk1KmSSmzgZ1Av5Isi5QyVUq5G8i4zbF9Usor9zL+4pKlgHQFNksp46WUCcBmoFthZSkVyiI3QogAoAHak7D3dYEt716War5ARK5mkYCvEMIK+AJ4K5/T3Lb9fx37zTxoWYQQOiHEUSAG7Ue1v7TKgqboNgkhDgkhXiqsHFAiZLnOEGDFvUtwgwcsy0mgjWVpxx7tSdmvhMtyX/gvslg+2wohAoUQ+4QQfbk9RXofK1U5uIUQjsBqYKyUMkkIcceqtymTwKvAeillxF3a3q19kVESZJFSmoD6QogywO9CiMeklPdsiykJsgCPSykvCyG8gM1CiGDLLPCeKCGyIIQwAL2BiQUZ921P8IBlkVKeFkLMQHuiTUFbqsou6PjznOD+yVLsFIEsAP6W33slYJsQ4oSU8vw9tL9nSo2yEEJYo13gZVLK3yzF0UKIclLKK5bpWYylPJK8TzDlgctAC6C1EOJVwBEwWAw8+4EPLHVfuEv7h1IWKeU1IcQOtCnqPSmLkiKLlPL6e4wQ4ne0ZZB7UhYlRRYLTwCHpZTR9yJDSZNFSrkQWGgZ0yeWuiVWFinlPW+OeACy5P69h1r+dxsIITyAuZa6ky3t293UfkehBy8LaRC8ny80DbkEmH1T+UzyGoY+s3zuQV7D0IHb9PkcdzZy1SavwS6UXMZHIIDCG7hLhCyAJ1DGUscO2AX0LKWyOABOljoOwB6gW2mUJdfxlcCI0vwbsxzzsrz7A8FYDKwlVZYCyltYA3eRyIJmrLaxfPYAzgG1bnM+N+CCpb6r5bNbYWW5Z4EfxAttd4IEjgNHLa/ugDuw1XKxtl6/EJaL+w3arowTQON7/cEA71ranwGeyFW+ArgCGNE098jSKAtQFzhiGcdJYHJp/bsAldBuVseAIODd0iqLpdweiANcHoL/l13AKcvfpmMpkSUMbRNLCtr/eC1L+WeW72bL+5QHIQvQ0vL9mOX9jvcg4Hm0DQch5Hr4KIwsyoNboVAoFPlS6nZDKRQKheL+o5SFQqFQKPJFKQuFQqFQ5ItSFgqFQqHIF6UsFAqFQpEvSlkoFIUkV+TPIKFF7x1vCStxtzYBQoih92uMCkVRoZSFQlF40qWU9aWUtYHOaHvmP8inTQCglIWi1KH8LBSKQiKESJFSOub6Xgk4iOZVWwFYiuZRDjBaSrlHCLEPLRrrBbQIo/8HTEcLy2ADfCOlnItCUcJQykKhKCQ3KwtLWQJQA0gGzFLKDCFEVWCFlLKxEKId8KaUsqel/ktoITE+FkLYAP8CA6UW6luhKDGUmkCCCkUp4XqkT2vgayFEfcAEVLtD/S5AXSHEAMt3F6Aq2sxDoSgxKGWhUBQRlmUoE1rU0A+AaKAemm3wlmQ615sBY6SUG+/LIBWKQqIM3ApFESCE8AS+RwtQJ9FmCFeklGZgGFp0XNCWp5xyNd0IvGIJXY0QopoQwgGFooShZhYKReGxs2QatEZL6rMUmGU59i2wWggxENgOpFrKjwPZQohjwGK0nNABwGGhZcG5yo20mgpFiUEZuBUKhUKRL2oZSqFQKBT5opSFQqFQKPJFKQuFQqFQ5ItSFgqFQqHIF6UsFAqFQpEvSlkoFAqFIl+UslAoFApFvihloVAoFIp8+X97pB+aKPrG0wAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fbed8c648d0>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "alpha_factors = [\"USFASTD_1DREVRSL\", \"USFASTD_EARNYILD\", \"USFASTD_VALUE\", \"USFASTD_SENTMT\"]\n",
+    "\n",
+    "facret_df = pd.DataFrame(index = my_dates)\n",
+    "\n",
+    "for dt in my_dates: \n",
+    "    for alp in alpha_factors: \n",
+    "        facret_df.at[dt, alp] = facret[dt.strftime('%Y%m%d')][alp]\n",
+    "\n",
+    "for column in facret_df.columns:\n",
+    "        plt.plot(facret_df[column].cumsum(), label=column)\n",
+    "plt.legend(loc='upper left')\n",
+    "plt.xlabel('Date')\n",
+    "plt.ylabel('Cumulative Factor Returns')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Merge Previous Portfolio Holdings \n",
+    "\n",
+    "In order to optimize our portfolio we will use the previous day's holdings to estimate the trade size and transaction costs. In order to keep track of the holdings from the previous day we will include a column to hold the portfolio holdings of the previous day. These holdings of all our assets will be initialized to zero when the backtest first starts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_nas(df): \n",
+    "    numeric_columns = df.select_dtypes(include=[np.number]).columns.tolist()\n",
+    "    \n",
+    "    for numeric_column in numeric_columns: \n",
+    "        df[numeric_column] = np.nan_to_num(df[numeric_column])\n",
+    "    \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "previous_holdings = pd.DataFrame(data = {\"Barrid\" : [\"USA02P1\"], \"h.opt.previous\" : np.array(0)})\n",
+    "df = frames[my_dates[0].strftime('%Y%m%d')]\n",
+    "\n",
+    "df = df.merge(previous_holdings, how = 'left', on = 'Barrid')\n",
+    "df = clean_nas(df)\n",
+    "df.loc[df['SpecRisk'] == 0]['SpecRisk'] = median(df['SpecRisk'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build Universe Based on Filters (TODO)\n",
+    "\n",
+    "In the cell below, implement the function `get_universe` that creates a stock universe by selecting only those companies that have a market capitalization of at least 1 billion dollars **OR** that are in the previous day's holdings, even if on the current day, the company no longer meets the 1 billion dollar criteria.\n",
+    "\n",
+    "When creating the universe, make sure you use the `.copy()` attribute to create a copy of the data. Also, it is very important to make sure that we are not looking at returns when forming the portfolio! to make this impossible, make sure to drop the column containing the daily return."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_universe(df):\n",
+    "    \"\"\"\n",
+    "    Create a stock universe based on filters\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    df : DataFrame\n",
+    "        All stocks\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    universe : DataFrame\n",
+    "        Selected stocks based on filters\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: Implement\n",
+    "    universe = df.loc[(df['IssuerMarketCap'] >= 1e9) | \\\n",
+    "                      (abs(df['h.opt.previous']) > 0)].copy()\n",
+    "    universe = universe.drop(columns = 'DlyReturn')\n",
+    "    \n",
+    "    return universe\n",
+    "\n",
+    "universe = get_universe(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "date = str(int(universe['DataDate'][1])) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Factors\n",
+    "\n",
+    "We will now extract both the risk factors and alpha factors. We begin by first getting all the factors using the `factors_from_names` function defined previously."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_factors = factors_from_names(list(universe))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will now create the function `setdiff` to just select the factors that we have not defined as alpha factors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def setdiff(temp1, temp2): \n",
+    "    s = set(temp2)\n",
+    "    temp3 = [x for x in temp1 if x not in s]\n",
+    "    return temp3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "risk_factors = setdiff(all_factors, alpha_factors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will also save the column that contains the previous holdings in a separate variable because we are going to use it later when we perform our portfolio optimization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h0 = universe['h.opt.previous']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matrix of Risk Factor Exposures\n",
+    "\n",
+    "Our dataframe contains several columns that we'll use as risk factors exposures.  Extract these and put them into a matrix.\n",
+    "\n",
+    "The data, such as industry category, are already one-hot encoded, but if this were not the case, then using `patsy.dmatrices` would help, as this function extracts categories and performs the one-hot encoding.  We'll practice using this package, as you may find it useful with future data sets.  You could also store the factors in a dataframe if you prefer.\n",
+    "\n",
+    "#### How to use patsy.dmatrices\n",
+    "\n",
+    "`patsy.dmatrices` takes in a formula and the dataframe.  The formula tells the function which columns to take.  The formula will look something like this:  \n",
+    "`SpecRisk ~ 0 + USFASTD_AERODEF + USFASTD_AIRLINES + ...`  \n",
+    "where the variable to the left of the ~ is the \"dependent variable\" and the others to the right are the independent variables (as if we were preparing data to be fit to a model).\n",
+    "\n",
+    "This just means that the `pasty.dmatrices` function will return two matrix variables, one that contains the single column for the dependent variable `outcome`, and the independent variable columns are stored in a matrix `predictors`.\n",
+    "\n",
+    "The `predictors` matrix will contain the matrix of risk factors, which is what we want.  We don't actually need the `outcome` matrix; it's just created because that's the way patsy.dmatrices works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "formula = get_formula(risk_factors, \"SpecRisk\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def model_matrix(formula, data): \n",
+    "    outcome, predictors = patsy.dmatrices(formula, data)\n",
+    "    return predictors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B = model_matrix(formula, universe)\n",
+    "BT = B.transpose()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate Specific Variance\n",
+    "\n",
+    "Notice that the specific risk data is in percent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0     9.014505\n",
+       "1    11.726327\n",
+       "Name: SpecRisk, dtype: float64"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "universe['SpecRisk'][0:2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Therefore, in order to get the specific variance for each stock in the universe we first need to multiply these values by `0.01`  and then square them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specVar = (0.01 * universe['SpecRisk']) ** 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Factor covariance matrix (TODO)\n",
+    "\n",
+    "Note that we already have factor covariances from Barra data, which is stored in the variable `covariance`.  `covariance` is a dictionary, where the key is each day's date, and the value is a dataframe containing the factor covariances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Factor1</th>\n",
+       "      <th>Factor2</th>\n",
+       "      <th>VarCovar</th>\n",
+       "      <th>DataDate</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>USFASTD_1DREVRSL</td>\n",
+       "      <td>USFASTD_1DREVRSL</td>\n",
+       "      <td>1.958869</td>\n",
+       "      <td>20040102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>USFASTD_1DREVRSL</td>\n",
+       "      <td>USFASTD_BETA</td>\n",
+       "      <td>1.602458</td>\n",
+       "      <td>20040102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>USFASTD_1DREVRSL</td>\n",
+       "      <td>USFASTD_DIVYILD</td>\n",
+       "      <td>-0.012642</td>\n",
+       "      <td>20040102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>USFASTD_1DREVRSL</td>\n",
+       "      <td>USFASTD_DWNRISK</td>\n",
+       "      <td>-0.064387</td>\n",
+       "      <td>20040102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>USFASTD_1DREVRSL</td>\n",
+       "      <td>USFASTD_EARNQLTY</td>\n",
+       "      <td>0.046573</td>\n",
+       "      <td>20040102</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Factor1           Factor2  VarCovar  DataDate\n",
+       "0  USFASTD_1DREVRSL  USFASTD_1DREVRSL  1.958869  20040102\n",
+       "1  USFASTD_1DREVRSL      USFASTD_BETA  1.602458  20040102\n",
+       "2  USFASTD_1DREVRSL   USFASTD_DIVYILD -0.012642  20040102\n",
+       "3  USFASTD_1DREVRSL   USFASTD_DWNRISK -0.064387  20040102\n",
+       "4  USFASTD_1DREVRSL  USFASTD_EARNQLTY  0.046573  20040102"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "covariance['20040102'].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the code below, implement the function `diagonal_factor_cov` to create the factor covariance matrix. Note that the covariances are given in percentage units squared.  Therefore you must re-scale them appropriately so that they're in decimals squared. Use the given `colnames` function to get the column names from `B`. \n",
+    "\n",
+    "When creating factor covariance matrix, you can store the factor variances and covariances, or just store the factor variances.  Try both, and see if you notice any differences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def colnames(B):\n",
+    "    if type(B) == patsy.design_info.DesignMatrix: \n",
+    "        return B.design_info.column_names\n",
+    "    if type(B) == pandas.core.frame.DataFrame: \n",
+    "        return B.columns.tolist()\n",
+    "    return None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def diagonal_factor_cov(date, B):\n",
+    "    \"\"\"\n",
+    "    Create the factor covariance matrix\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    date : string\n",
+    "           date. For example 20040102\n",
+    "        \n",
+    "    B : patsy.design_info.DesignMatrix OR pandas.core.frame.DataFrame\n",
+    "        Matrix of Risk Factors\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    Fm : Numpy ndarray\n",
+    "        factor covariance matrix\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: Implement\n",
+    "    cv = covariance[date]\n",
+    "    k = (np.shape(B)[1])\n",
+    "    Fm = np.zeros([k,k])\n",
+    "    for j in range(0,k): \n",
+    "        fac = colnames(B)[j]\n",
+    "        var = (cv.loc[(cv.Factor1==fac) & (cv.Factor2==fac),\"VarCovar\"].iloc[0])\n",
+    "        Fm[j,j] = (0.01**2) * var # ...\n",
+    "    \n",
+    "    return (Fm)\n",
+    "\n",
+    "Fvar = diagonal_factor_cov(date, B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transaction Costs\n",
+    "\n",
+    "To get the transaction cost, or slippage, we have to multiply the price change due to market impact by the amount of dollars traded:\n",
+    "\n",
+    "$$\n",
+    "\\mbox{tcost_{i,t}} = \\% \\Delta \\mbox{price}_{i,t} \\times \\mbox{trade}_{i,t}\n",
+    "$$\n",
+    "\n",
+    "In summation notation it looks like this:  \n",
+    "$$\n",
+    "\\mbox{tcost}_{i,t} = \\sum_i^{N} \\lambda_{i,t} (h_{i,t} - h_{i,t-1})^2\n",
+    "$$  \n",
+    "where\n",
+    "$$\n",
+    "\\lambda_{i,t} = \\frac{1}{10\\times \\mbox{ADV}_{i,t}}\n",
+    "$$\n",
+    "\n",
+    "Note that since we're dividing by ADV, we'll want to handle cases when ADV is missing or zero.  In those instances, we can set ADV to a small positive number, such as 10,000, which, in practice assumes that the stock is illiquid. In the code below if there is no volume information we assume the asset is illiquid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_lambda(universe, composite_volume_column = 'ADTCA_30'):\n",
+    "    universe.loc[np.isnan(universe[composite_volume_column]), composite_volume_column] = 1.0e4\n",
+    "    universe.loc[universe[composite_volume_column] == 0, composite_volume_column] = 1.0e4 \n",
+    "\n",
+    "    adv = universe[composite_volume_column]\n",
+    "    \n",
+    "    return 0.1 / adv\n",
+    "\n",
+    "Lambda = get_lambda(universe)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Alpha Combination (TODO)\n",
+    "\n",
+    "In the code below create a matrix of alpha factors and return it from the function `get_B_alpha`. Create this matrix in the same way you created the matrix of risk factors, i.e. using the `get_formula` and `model_matrix` functions we have defined above. Feel free to go back and look at the previous code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_B_alpha(alpha_factors, universe):\n",
+    "    # TODO: Implement\n",
+    "    B_alpha = model_matrix(get_formula(alpha_factors, \"SpecRisk\"), data = universe)\n",
+    "    \n",
+    "    return B_alpha\n",
+    "\n",
+    "B_alpha = get_B_alpha(alpha_factors, universe)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that you have the matrix containing the alpha factors we will combine them by adding its rows. By doing this we will collapse the `B_alpha` matrix into a single alpha vector. We'll multiply by `1e-4` so that the expression of expected portfolio return, $\\alpha^T \\mathbf{h}$, is in dollar units. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_alpha_vec(B_alpha):\n",
+    "    \"\"\"\n",
+    "    Create an alpha vecrtor\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------        \n",
+    "    B_alpha : patsy.design_info.DesignMatrix \n",
+    "        Matrix of Alpha Factors\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    alpha_vec : patsy.design_info.DesignMatrix \n",
+    "        alpha vecrtor\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: Implement\n",
+    "    scale = 1e-4\n",
+    "    alpha_vec = scale * np.sum(B_alpha, axis=1)\n",
+    "    \n",
+    "    return alpha_vec\n",
+    "\n",
+    "alpha_vec = get_alpha_vec(B_alpha)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Optional Challenge\n",
+    "\n",
+    "You can also try to a more sophisticated method of alpha combination, by choosing the holding for each alpha based on the same metric of its performance, such as the factor returns, or sharpe ratio.  To make this more realistic, you can calculate a rolling average of the sharpe ratio, which is updated for each day.  Remember to only use data that occurs prior to the date of each optimization, and not data that occurs in the future.  Also, since factor returns and sharpe ratios may be negative, consider using a `max` function to give the holdings a lower bound of zero."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Objective function (TODO)\n",
+    "\n",
+    "The objective function is given by:\n",
+    "\n",
+    "$$\n",
+    "f(\\mathbf{h}) = \\frac{1}{2}\\kappa \\mathbf{h}_t^T\\mathbf{Q}^T\\mathbf{Q}\\mathbf{h}_t + \\frac{1}{2} \\kappa \\mathbf{h}_t^T \\mathbf{S} \\mathbf{h}_t - \\mathbf{\\alpha}^T \\mathbf{h}_t + (\\mathbf{h}_{t} - \\mathbf{h}_{t-1})^T \\mathbf{\\Lambda} (\\mathbf{h}_{t} - \\mathbf{h}_{t-1})\n",
+    "$$\n",
+    "\n",
+    "Where the terms correspond to: factor risk + idiosyncratic risk - expected portfolio return + transaction costs, respectively. We should also note that $\\textbf{Q}^T\\textbf{Q}$ is defined to be the same as $\\textbf{BFB}^T$.  Review the lessons if you need a refresher of how we get $\\textbf{Q}$.\n",
+    "\n",
+    "Our objective is to minimize this objective function. To do this, we will use Scipy's optimization function:\n",
+    "\n",
+    "`scipy.optimize.fmin_l_bfgs_b(func, initial_guess, func_gradient)`\n",
+    "\n",
+    "where:\n",
+    "\n",
+    "* **func** : is the function we want to minimize\n",
+    "\n",
+    "* **initial_guess** : is out initial guess\n",
+    "\n",
+    "* **func_gradient** : is the gradient of the function we want to minimize\n",
+    "\n",
+    "So, in order to use the `scipy.optimize.fmin_l_bfgs_b` function we first need to define its parameters.\n",
+    "\n",
+    "In the code below implement the function `obj_func(h)` that corresponds to the objective function above that we want to minimize. We will set the risk aversion to be `1.0e-6`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "risk_aversion = 1.0e-6\n",
+    "\n",
+    "def get_obj_func(h0, risk_aversion, Q, specVar, alpha_vec, Lambda): \n",
+    "    def obj_func(h):\n",
+    "        # TODO: Implement\n",
+    "        f = 0.0\n",
+    "        f += 0.5 * risk_aversion * np.sum( np.matmul(Q, h) ** 2 )\n",
+    "        f += 0.5 * risk_aversion * np.dot(h ** 2, specVar)\n",
+    "        f -= np.dot(h, alpha_vec)\n",
+    "        f += np.dot( (h - h0) ** 2, Lambda) \n",
+    "        \n",
+    "        return (f)\n",
+    "    \n",
+    "    return obj_func"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gradient (TODO)\n",
+    "\n",
+    "Now that we can generate the objective function using `get_obj_func`, we can now create a similar function with its gradient. The reason we're interested in calculating the gradient is so that we can tell the optimizer in which direction, and how much, it should shift the portfolio holdings in order to improve the objective function (minimize variance, minimize transaction cost, and maximize expected portfolio return).\n",
+    "\n",
+    "Before we implement the function we first need to know what the gradient looks like. The gradient, or derivative of the objective function, with respect to the portfolio holdings h, is given by:  \n",
+    "\n",
+    "$$\n",
+    "f'(\\mathbf{h}) = \\frac{1}{2}\\kappa (2\\mathbf{Q}^T\\mathbf{Qh}) + \\frac{1}{2}\\kappa (2\\mathbf{Sh}) - \\mathbf{\\alpha} + 2(\\mathbf{h}_{t} - \\mathbf{h}_{t-1}) \\mathbf{\\Lambda}\n",
+    "$$\n",
+    "\n",
+    "In the code below, implement the function `grad(h)` that corresponds to the function of the gradient given above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_grad_func(h0, risk_aversion, Q, QT, specVar, alpha_vec, Lambda):\n",
+    "    def grad_func(h):\n",
+    "        # TODO: Implement\n",
+    "        g = risk_aversion * (np.matmul(QT, np.matmul(Q,h)) + (specVar * h) ) \\\n",
+    "        - alpha_vec \\\n",
+    "        + 2 * (h-h0) * Lambda\n",
+    "        \n",
+    "        return (np.asarray(g))\n",
+    "    \n",
+    "    return grad_func"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optimize (TODO)\n",
+    "\n",
+    "Now that we can generate the objective function using `get_obj_func`, and its corresponding gradient using `get_grad_func` we are ready to minimize the objective function using Scipy's optimization function. For this, we will use out initial holdings as our `initial_guess` parameter.\n",
+    "\n",
+    "In the cell below, implement the function `get_h_star` that optimizes the objective function. Use the objective function (`obj_func`) and gradient function (`grad_func`) provided within `get_h_star` to optimize the objective function using the `scipy.optimize.fmin_l_bfgs_b` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "risk_aversion = 1.0e-6\n",
+    "\n",
+    "Q = np.matmul(scipy.linalg.sqrtm(Fvar), BT)\n",
+    "QT = Q.transpose()\n",
+    "\n",
+    "def get_h_star(risk_aversion, Q, QT, specVar, alpha_vec, h0, Lambda):\n",
+    "    \"\"\"\n",
+    "    Optimize the objective function\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------        \n",
+    "    risk_aversion : int or float \n",
+    "        Trader's risk aversion\n",
+    "        \n",
+    "    Q : patsy.design_info.DesignMatrix \n",
+    "        Q Matrix\n",
+    "        \n",
+    "    QT : patsy.design_info.DesignMatrix \n",
+    "        Transpose of the Q Matrix\n",
+    "        \n",
+    "    specVar: Pandas Series \n",
+    "        Specific Variance\n",
+    "        \n",
+    "    alpha_vec: patsy.design_info.DesignMatrix \n",
+    "        alpha vector\n",
+    "        \n",
+    "    h0 : Pandas Series  \n",
+    "        initial holdings\n",
+    "        \n",
+    "    Lambda : Pandas Series  \n",
+    "        Lambda\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    optimizer_result[0]: Numpy ndarray \n",
+    "        optimized holdings\n",
+    "    \"\"\"\n",
+    "    obj_func = get_obj_func(h0, risk_aversion, Q, specVar, alpha_vec, Lambda)\n",
+    "    grad_func = get_grad_func(h0, risk_aversion, Q, QT, specVar, alpha_vec, Lambda)\n",
+    "    \n",
+    "    # TODO: Implement\n",
+    "    optimizer_result = scipy.optimize.fmin_l_bfgs_b(obj_func, h0, fprime=grad_func)\n",
+    "    \n",
+    "    return optimizer_result[0]\n",
+    "\n",
+    "h_star = get_h_star(risk_aversion, Q, QT, specVar, alpha_vec, h0, Lambda)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After we have optimized our objective function we can now use, `h_star` to create our optimal portfolio:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opt_portfolio = pd.DataFrame(data = {\"Barrid\" : universe['Barrid'], \"h.opt\" : h_star})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Risk Exposures (TODO)\n",
+    "\n",
+    "We can also use `h_star` to calculate our portfolio's risk and alpha exposures.\n",
+    "\n",
+    "In the cells below implement the functions `get_risk_exposures` and `get_portfolio_alpha_exposure` that calculate the portfolio's risk and alpha exposures, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_risk_exposures(B, BT, h_star):\n",
+    "    \"\"\"\n",
+    "    Calculate portfolio's Risk Exposure\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    B : patsy.design_info.DesignMatrix \n",
+    "        Matrix of Risk Factors\n",
+    "        \n",
+    "    BT : patsy.design_info.DesignMatrix \n",
+    "        Transpose of Matrix of Risk Factors\n",
+    "        \n",
+    "    h_star: Numpy ndarray \n",
+    "        optimized holdings\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    risk_exposures : Pandas Series\n",
+    "        Risk Exposures\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: Implement\n",
+    "    risk_exposures = pd.Series(np.matmul(B.T, h_star), index = colnames(B))\n",
+    "    \n",
+    "    return risk_exposures\n",
+    "\n",
+    "risk_exposures = get_risk_exposures(B, BT, h_star)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_portfolio_alpha_exposure(B_alpha, h_star):\n",
+    "    \"\"\"\n",
+    "    Calculate portfolio's Alpha Exposure\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    B_alpha : patsy.design_info.DesignMatrix \n",
+    "        Matrix of Alpha Factors\n",
+    "        \n",
+    "    h_star: Numpy ndarray \n",
+    "        optimized holdings\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    alpha_exposures : Pandas Series\n",
+    "        Alpha Exposures\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: Implement\n",
+    "    alpha_exposures = pd.Series(np.matmul(B_alpha.transpose(), h_star), index = colnames(B_alpha))\n",
+    "    \n",
+    "    return alpha_exposures\n",
+    "\n",
+    "portfolio_alpha_exposure = get_portfolio_alpha_exposure(B_alpha, h_star)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transaction Costs (TODO)\n",
+    "\n",
+    "We can also use `h_star` to calculate our total transaction costs:\n",
+    "$$\n",
+    "\\mbox{tcost} = \\sum_i^{N} \\lambda_{i} (h_{i,t} - h_{i,t-1})^2\n",
+    "$$\n",
+    "\n",
+    "In the cell below, implement the function `get_total_transaction_costs` that calculates the total transaction costs according to the equation above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_total_transaction_costs(h0, h_star, Lambda):\n",
+    "    \"\"\"\n",
+    "    Calculate Total Transaction Costs\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    h0 : Pandas Series\n",
+    "        initial holdings (before optimization)\n",
+    "        \n",
+    "    h_star: Numpy ndarray \n",
+    "        optimized holdings\n",
+    "        \n",
+    "    Lambda : Pandas Series  \n",
+    "        Lambda\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    total_transaction_costs : float\n",
+    "        Total Transaction Costs\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: Implement\n",
+    "    total_transaction_costs = (Lambda * (h_star - h0)**2).sum()\n",
+    "    \n",
+    "    return total_transaction_costs\n",
+    "\n",
+    "total_transaction_costs = get_total_transaction_costs(h0, h_star, Lambda)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Putting It All Together\n",
+    "\n",
+    "We can now take all the above functions we created above and use them to create a single function, `form_optimal_portfolio` that returns the optimal portfolio, the risk and alpha exposures, and the total transactions costs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def form_optimal_portfolio(df, previous, risk_aversion):\n",
+    "    df = df.merge(previous, how = 'left', on = 'Barrid')\n",
+    "    df = clean_nas(df)\n",
+    "    df.loc[df['SpecRisk'] == 0]['SpecRisk'] = median(df['SpecRisk'])\n",
+    "  \n",
+    "    universe = get_universe(df)\n",
+    "    date = str(int(universe['DataDate'][1]))\n",
+    "  \n",
+    "    all_factors = factors_from_names(list(universe))\n",
+    "    risk_factors = setdiff(all_factors, alpha_factors)\n",
+    "  \n",
+    "    h0 = universe['h.opt.previous']\n",
+    "  \n",
+    "    B = model_matrix(get_formula(risk_factors, \"SpecRisk\"), universe)\n",
+    "    BT = B.transpose()\n",
+    "  \n",
+    "    specVar = (0.01 * universe['SpecRisk']) ** 2\n",
+    "    Fvar = diagonal_factor_cov(date, B)\n",
+    "    \n",
+    "    Lambda = get_lambda(universe)\n",
+    "    B_alpha = get_B_alpha(alpha_factors, universe)\n",
+    "    alpha_vec = get_alpha_vec(B_alpha)\n",
+    "  \n",
+    "    Q = np.matmul(scipy.linalg.sqrtm(Fvar), BT)\n",
+    "    QT = Q.transpose()\n",
+    "    \n",
+    "    h_star = get_h_star(risk_aversion, Q, QT, specVar, alpha_vec, h0, Lambda)\n",
+    "    opt_portfolio = pd.DataFrame(data = {\"Barrid\" : universe['Barrid'], \"h.opt\" : h_star})\n",
+    "    \n",
+    "    risk_exposures = get_risk_exposures(B, BT, h_star)\n",
+    "    portfolio_alpha_exposure = get_portfolio_alpha_exposure(B_alpha, h_star)\n",
+    "    total_transaction_costs = get_total_transaction_costs(h0, h_star, Lambda)\n",
+    "  \n",
+    "    return {\n",
+    "        \"opt.portfolio\" : opt_portfolio, \n",
+    "        \"risk.exposures\" : risk_exposures, \n",
+    "        \"alpha.exposures\" : portfolio_alpha_exposure,\n",
+    "        \"total.cost\" : total_transaction_costs}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build tradelist\n",
+    "\n",
+    "The trade list is the most recent optimal asset holdings minus the previous day's optimal holdings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_tradelist(prev_holdings, opt_result):\n",
+    "    tmp = prev_holdings.merge(opt_result['opt.portfolio'], how='outer', on = 'Barrid')\n",
+    "    tmp['h.opt.previous'] = np.nan_to_num(tmp['h.opt.previous'])\n",
+    "    tmp['h.opt'] = np.nan_to_num(tmp['h.opt'])\n",
+    "    return tmp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save optimal holdings as previous optimal holdings.\n",
+    "\n",
+    "As we walk through each day, we'll re-use the column for previous holdings by storing the \"current\" optimal holdings as the \"previous\" optimal holdings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_previous(result): \n",
+    "    prev = result['opt.portfolio']\n",
+    "    prev = prev.rename(index=str, columns={\"h.opt\": \"h.opt.previous\"}, copy=True, inplace=False)\n",
+    "    return prev"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the backtest\n",
+    "\n",
+    "Walk through each day, calculating the optimal portfolio holdings and trade list.  This may take some time, but should finish sooner if you've chosen all the optimizations you learned in the lessons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Optimizing Portfolio: 100%|██████████| 252/252 [23:23<00:00,  5.57s/day]\n"
+     ]
+    }
+   ],
+   "source": [
+    "trades = {}\n",
+    "port = {}\n",
+    "\n",
+    "for dt in tqdm(my_dates, desc='Optimizing Portfolio', unit='day'):\n",
+    "    date = dt.strftime('%Y%m%d')\n",
+    "\n",
+    "    result = form_optimal_portfolio(frames[date], previous_holdings, risk_aversion)\n",
+    "    trades[date] = build_tradelist(previous_holdings, result)\n",
+    "    port[date] = result\n",
+    "    previous_holdings = convert_to_previous(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profit-and-Loss (PnL) attribution (TODO)\n",
+    "\n",
+    "Profit and Loss is the aggregate realized daily returns of the assets, weighted by the optimal portfolio holdings chosen, and summed up to get the portfolio's profit and loss.\n",
+    "\n",
+    "The PnL attributed to the alpha factors equals the factor returns times factor exposures for the alpha factors.  \n",
+    "\n",
+    "$$\n",
+    "\\mbox{PnL}_{alpha}= f \\times b_{alpha}\n",
+    "$$\n",
+    "\n",
+    "Similarly, the PnL attributed to the risk factors equals the factor returns times factor exposures of the risk factors.\n",
+    "\n",
+    "$$\n",
+    "\\mbox{PnL}_{risk} = f \\times b_{risk}\n",
+    "$$\n",
+    "\n",
+    "In the code below, in the function `build_pnl_attribution` calculate the PnL attributed to the alpha factors, the PnL attributed to the risk factors, and attribution to cost. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## assumes v, w are pandas Series \n",
+    "def partial_dot_product(v, w):\n",
+    "    common = v.index.intersection(w.index)\n",
+    "    return np.sum(v[common] * w[common])\n",
+    "\n",
+    "def build_pnl_attribution(): \n",
+    "\n",
+    "    df = pd.DataFrame(index = my_dates)\n",
+    "    \n",
+    "    for dt in my_dates:\n",
+    "        date = dt.strftime('%Y%m%d')\n",
+    "\n",
+    "        p = port[date]\n",
+    "        fr = facret[date]\n",
+    "\n",
+    "        mf = p['opt.portfolio'].merge(frames[date], how = 'left', on = \"Barrid\")\n",
+    "        \n",
+    "        mf['DlyReturn'] = wins(mf['DlyReturn'], -0.5, 0.5)\n",
+    "        df.at[dt,\"daily.pnl\"] = np.sum(mf['h.opt'] * mf['DlyReturn'])\n",
+    "        \n",
+    "        # TODO: Implement\n",
+    "        \n",
+    "        df.at[dt,\"attribution.alpha.pnl\"] = partial_dot_product(fr, p[\"alpha.exposures\"])\n",
+    "        df.at[dt,\"attribution.risk.pnl\"] = partial_dot_product(fr, p[\"risk.exposures\"])\n",
+    "        df.at[dt,\"attribution.cost\"] = p[\"total.cost\"]\n",
+    "        \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzsnXd4VkXzsO9JB5IQAiR0AhJ6CRB6kSZFEUFBUVRAlFdEXyuK5VNE8Wd97YIoICoKWCgKiFIiSA+dUENNACEhpBESUvb7Y09CIO1JyJO693U913PO7J7dORgzmd3ZGVFKYTAYDAaDPXEobgUMBoPBUPYxxsZgMBgMdscYG4PBYDDYHWNsDAaDwWB3jLExGAwGg90xxsZgMBgMdscYG4PBYDDYHWNsDAaDwWB3jLExGAwGg91xKm4FSgrVqlVTfn5+xa2GwWAwlCq2b98eqZSqnlc/Y2ws/Pz8CA4OLm41DAaDoVQhIidt6WeW0QwGg8Fgd4yxMRgMBoPdsbuxERFHEdkpIr9b9w1EZIuIHBGRBSLiYsldrftQq90v0xgvWvJDIjIgk3ygJQsVkcmZ5NnOYTAYDIbioSj2bJ4EDgCe1v07wIdKqfkiMgMYB0y3vi8qpRqJyEir3z0i0hwYCbQAagGrRKSxNdbnwC1AOLBNRJYqpfbnMke+SE5OJjw8nMTExIK9uaHM4+bmRp06dXB2di5uVQyGEo1djY2I1AFuA6YBz4iIAH2A+6wuc4EpaENwh3UN8DPwmdX/DmC+UioJOC4ioUBHq1+oUuqYNdd84A4ROZDLHPkiPDwcDw8P/Pz80KoYDFdRSnHhwgXCw8Np0KBBcatjMJRo7L2M9hHwPJBm3VcFopVSKdZ9OFDbuq4NhAFY7TFW/wz5dc/kJM9tjmsQkfEiEiwiwREREVnaExMTqVq1qjE0hmwREapWrWo8X4PBBuxmbERkMHBeKbU9szibriqPtsKSZxUqNVMpFaiUCqxePfswcWNoDLlhfj4MBtuwp2fTDRgiIieA+eilrY8ALxFJX76rA5yxrsOBugBWe2UgKrP8umdykkfmMofBYDAY0rlyCVZMhqjjdp/KbsZGKfWiUqqOUsoPvcG/Rik1ClgLDLe6jQaWWNdLrXus9jVKKWXJR1rRag0Af2ArsA3wtyLPXKw5llrP5DRHqWbKlCm8//77ObbPmDGDb7/9FoAxY8bw888/202XlJQUvLy87Da+wWAoAvb9AlumQ9y/dp+qODIIvADMF5E3gZ3ALEs+C/jOCgCIQhsPlFIhIrIQ2A+kABOVUqkAIvI4sBJwBGYrpULymKNM8+ijjxa3CgaDoaSTFAcnN8HlKNj0BVRvBvU6233aIjnUqZQKUkoNtq6PKaU6KqUaKaVGWFFmKKUSrftGVvuxTM9PU0rdpJRqopRakUm+XCnV2Gqblkme7RylkWnTptGkSRP69evHoUOHAPjqq6/o0KEDbdq04a677iIhIQHI3vNZvXo1w4YNy7j/66+/uPPOO7PM0717d5566im6dOlCq1atMlL3vPLKK4wbN46bb76Zhg0b8vnnn9vrVQ0GQ1Hwx2T4YQQs+g9EHIAuj0ER7D2a3Gg28vpvIew/E1uoYzav5clrt7fIsX379u3Mnz+fnTt3kpKSQrt27Wjfvj133nknjzzyCKCNwaxZs3jiiSeyHaNPnz5MnDiRiIgIqlevzpw5cxg7dmy2fZOSkti0aRNr1qzh4YcfZteuXQAcPnyY1atXEx0dTbNmzYwHZTCUVhJjYd+v0HI49H4JKlaFCkWzHG7S1ZRg1q9fz7Bhw6hYsSKenp4MGTIEgH379tGjRw9atWrFvHnzCAkJyXEMEeGBBx7g+++/Jzo6mk2bNjFo0KBs+957772ANlDnz58nPj4egMGDB+Pi4oKPjw/e3t5kFyZuMBhKAQeXQXICdHoUqt5UZIYGjGdjM7l5IPYku9DaMWPGsHjxYtq0acM333xDUFBQrmOMHTuW22+/HTc3N0aMGIGTU/b/2a+fK/3e1dU1Q+bo6EhKSgoGg6EUcmI9VPCGOoFFPrXxbEowPXv2ZNGiRVy+fJm4uDh+++03AOLi4qhZsybJycnMmzcvz3Fq1apFrVq1ePPNNxkzZkyO/RYsWABAUFAQvr6+VKpUqVDew2AwFAPJlyH1uj8MT22Cel2KZI/meoxnU4Jp164d99xzDwEBAdSvX58ePXoA8MYbb9CpUyfq169Pq1atiIuLy3OsUaNGERERQfPmzTNkY8eO5cknnyQgIAAAT09PunbtSlxcHHPmzLHPSxkMBvuhrPPr+36BxRMg9Qq4uEOFKtB+NEQdg/bZ79naG1Eq28P15Y7AwEB1ffG0AwcO0KxZs2LSqHB5/PHHadu2LePGjcu2vXv37nz22WcZhsdgO2Xp58RQyghZBNu/gcBxEH0StnwJFb3h/EGo2Roa9YPL0XBqI5zdDeIAj24A3+Z5Dm0rIrJdKZXnupzxbMoB7du3p1KlSnzwwQfFrYrBYCgsUpPh1/HaezkWpGW1A+H0dqjiB/cugEpVtTw6DGb1hy4TC9XQ5AdjbMoB27dvz7PPP//8UwSaGAyGQuPCUW1oBrwFiTHQ5FaoFQBhW8Gr3lVDA+BVF54OAYfi26Y3xsZgMBhKIxEH9Xf9btrIpFO3Y/b9i9HQgIlGMxgMhtJJxEFAoFrjPLuWBIyxMRgMhtLIuRC9N+NSsbg1sQljbAwGg6G0ETwHDizVS2ilBGNsSilvvfVWxnV0dDRffPFFrv27du0K6AObgwcPztdcixcvZv/+/Rn3r776KqtWrcrXGPnF3d29UPoUJnmVeDAY7MKRVTqkOZ24f+HPV6BhL7it9ESYGmNTSrHV2KSmpgKwcePGAs91vbGZOnUq/fr1K/B4BoPBRpSCFZPgjxfhUqSWrX4DUpLgtv+Bs1vx6pcPjLEpBQwdOpT27dvTokULZs6cyeTJk7l8+TIBAQGMGjWKyZMnc/ToUQICApg0aRJBQUH07t2b++67j1atWgHXegGxsbEMGzaM5s2b8+ijj5KWlpalz88//8yYMWPYuHEjS5cuZdKkSQQEBHD06NFrCrOtXr2atm3b0qpVKx566CGSknQ1Bz8/P1577TXatWtHq1atOHjwYJb3io+Pp2/fvhl9lizJWuMuKCiInj17ZqsvwMsvv0ybNm3o3Lkz586dA+C3336jU6dOtG3bln79+mXIbR3X3d0923ENhiIlNRl2zNWn/lUq7F8MZ3bCrnnQ2UqkWYqwW+iziLgB6wBXa56flVKvicg3wM1AjNV1jFJql+isjx8DtwIJlnyHNdZo4BWr/5tKqbmWvD3wDVABWA48qZRSIuINLAD8gBPA3Uqpizf0Qismw797b2iILNRoBYPezrPb7Nmz8fb25vLly3To0IG///6bzz77LKMEwIkTJ9i3b1/GfVBQEFu3bmXfvn00aNAgy3hbt25l//791K9fn4EDB/Lrr78yfPjwLP1AL78NGTKEwYMHZ+mTmJjImDFjWL16NY0bN+bBBx9k+vTpPPXUUwBUq1aNHTt28MUXX/D+++/z9ddfX/O8m5sbixYtwtPTk8jISDp37syQIUOyJATNSd9Lly7RuXNnpk2bxvPPP89XX33FK6+8Qvfu3dm8eTMiwtdff827776b7YHW/I5rMBQZ/3wEmz6DSxFQ1V/LNn6mswNUrAo9JxWvfgXAnp5NEtBHKdUGCAAGikh6ObhJSqkA67PLkg1Cl3z2B8YD0wEsw/Ea0AnoCLwmIlWsZ6ZbfdOfG2jJJwOrlVL+wGrrvtTyySefZPyVHRYWxpEjR/J8pmPHjtkamvS2hg0b4ujoyL333lvgA52HDh2iQYMGNG6sQy9Hjx7NunXrMtrTi7S1b9+eEydOZHleKcVLL71E69at6devH6dPn87Wi8hJXxcXl4z9p8xzhIeHM2DAAFq1asV7772XYwmG/I5rMNgVpSApHiIOw6rXoHpTuHc+PLYJ+r8BF4/r7AC3vA5ulYtb23xjN89G6aRr8dats/XJLRHbHcC31nObRcRLRGoCvYC/lFJRACLyF9pwBQGeSqlNlvxbYCiwwhqrlzXuXCAIXSq64NjggdiDoKAgVq1axaZNm6hYsSK9evUiMTExz+dyy9icUymBzHJb5sgrr156aYKcyhLMmzePiIgItm/fjrOzM35+ftnOm5O+zs7OGdeZ53jiiSd45plnGDJkCEFBQUyZMiVb/fI7rsFgNyIOwx8v6NP/dTroHGZ3zQIPX93eZBAM/hC86kOjvsWrawGx656NiDiKyC7gPNpgbLGaponIHhH5UETSi6XUBsIyPR5uyXKTh2cjB/BVSp0FsL59CvG1ipSYmBiqVKlCxYoVOXjwIJs3bwb0L8Tk5GQAPDw8bMr8nM7WrVs5fvw4aWlpLFiwgO7duwPg6+vLgQMHSEtLY9GiRRn9cxq/adOmnDhxgtDQUAC+++47br755ny9m4+PD87Ozqxdu5aTJ0/mS9/cxq1dW/8ozJ07N8d++R3XYCh0QlfDN4Ph8w5wYgM4OsOxtTr1TLqhSSfwoVJraMDOxkYplaqUCgDqAB1FpCXwItAU6AB4c9XjyK7AgiqA3GZEZLyIBItIcEmtPjlw4EBSUlJo3bo1/+///T86d9YrkePHj6d169aMGjWKqlWr0q1bN1q2bMmkSXmv5Xbp0oXJkyfTsmVLGjRowLBhwwB4++23GTx4MH369KFmzZoZ/UeOHMl7771H27ZtOXr0aIbczc2NOXPmMGLECFq1aoWDg0OeJaODg4N5+OGHAV32IDg4mMDAQObNm0fTpk3zpW9OTJkyhREjRtCjRw+qVauW7dwFGddgKFS2z4Xv74KLJ6Hvq/D0Phj7BwyfDXfOLG7tCh+lVJF80Psuz10n6wX8bl1/Cdybqe0QUBO4F/gyk/xLS1YTOJhJntEv/VnruiZwKC/92rdvr65n//79WWSGomXt2rXqtttuK9Hjmp8TQ77ZNkup1zyV+u5OpZIuFbc2NwQQrGywAXbzbESkuoh4WdcVgH7AQWsfBiv6bCiwz3pkKfCgaDoDMUovga0E+otIFSswoD+w0mqLE5HO1lgPAksyjTXauh6dSW4wGAzFR/h2mDUAlj0L/gNg5I+lJt3MjWLPrM81gbki4oherluolPpdRNaISHX0MtguIH3dZTk67DkUHfo8FkApFSUibwDbrH5TlRUsAEzgaujzCusD8DawUETGAaeAEXZ7S4Nd6dWrF7169So14xoM13D+IKx8SS+N7Vmor919ofNj0OtFcHIpbg2LDHtGo+0B2mYj75NDfwVMzKFtNjA7G3kw0DIb+QWg9O6kGQyGssHGT+DoanivEaQla29m2Ax9XqacYerZGAwGg71Is8Lm05Ih4H4Y8mmx15UpLsrnWxsMBkNREJEpTVO/18qtoQHj2RgMBkPhcOEoeDeEmHCIOKRzmp3dDR3/A71fggpexa1hsVJ+zWwpp6yWGEjXMyfsUVagIP8mhnLK1q/g+Pqs8v1L4dN28HU/+KglzLtLZ2sG8G1R7g0NGGNTailrJQYKQ0+Dwa6kJsPy52DuYJ3HLB2lYMPH+vp0MNRoDWNXwISN0O1JaD6kePQtYRhjUwooqyUGctPz7Nmz9OzZk4CAAFq2bMn69df+NRkZGUmXLl1YtmxZlnHd3d159tlnadeuHX379iU9O0SvXr144YUX6NixI40bN84ypsGQheRECJ4Nl6MhMlMC3GNBV69DFmkjk06r4VC/q/ZobpkKFapgMHs2NvPO1nc4GJX1F+aN0NS7KS90zDs/aFktMZCuS3Z6/vDDDwwYMICXX36Z1NRUEhISMtrOnTvHkCFDePPNN7nllluyjHnp0iXatWvHBx98wNSpU3n99df57LPPAEhJSWHr1q0sX76c119/3e4VRw2lnG1fw58vw7bZ0GbkVfmC+yFwLBwNgnN7tTfT4WH4/Smd18yQBePZlALKaomB3PTs0KEDc+bMYcqUKezduxcPDw8AkpOT6du3L++++262hgbAwcGBe+65B4D777//mvezRSeDAYDUFNg8XdeTuRCqjY6jqw5fvhKv68tU8NJ5zUb9DG0fgMeDoZp/cWteIjGejY3Y4oHYg7JcYiA3PXv27Mm6detYtmwZDzzwAJMmTeLBBx/EycmJ9u3bs3LlSpszTGd+L1t0MpQRUpJAHMEx0685peDEP/oUf/XGuT8ftgViw2H4HPCsBfNGgE8zbVSqNtLLZNfXlSll1TOLEuPZlHDKcomB3Dh58iQ+Pj488sgjjBs3jh07dgDacMyePZuDBw/y9tvZ1xhKS0vL2FP64YcfTOmA8sp3d8InAXB45VXZ4sf0Bv/nHWD+KAh6B9a9l/3zh/8AB2do1A/qdYaJW2HENyCi92RKYQGz4sQYmxJOWS4xkBtBQUEEBATQtm1bfvnlF5588smMNkdHR+bPn8/atWszovACAgIy2itVqkRISAjt27dnzZo1vPrqq3nOZyhjRJ+Ck/9AQhT8cDf8NAZCFsPuH6DTBOj5vPZwgt6CNW/qfpm5kgAHfrOMiqeWedbUHo6hQEheSyHlhcDAQBUcHHyN7MCBAzRr1qyYNDIUFHd3d+Lj4/PuWEiYn5MSRvJlWP8/WPcuPLYZDv6uPZi0ZF3pcuIWcK4ASXGwfwksmairYkafBAcnfTBz29dwfB3cuwAa9y/uNyrRiMh2pVRgXv3Mno3BYCg7bJ4Bf76iDUu9rnqPxacZNLgZDi6DLhO1oQFw9YDWI+GPl+CXcdeO4+AEd3xuDE0hYoyNocxRlF6NoYSQlgorX4Yt03Vm5XYPgn+maMW6HfXnehydoPtTsPYtaHknDHoHoo7r/Riz2V+oGGNjMBhKN1cS4NdH9HJZpwkwYBo4ONr+fI9noON47fE4OEJtcwjTHpgAAYPBULpZNUUvkQ18Gwa9nT9Dk46re8GeK+WERSUw6OP1bD0elXfnG8SeZaHdRGSriOwWkRARed2SNxCRLSJyREQWiIiLJXe17kOtdr9MY71oyQ+JyIBM8oGWLFREJmeSZzuHwWAog0QcgDodoPOE4tak1LHxaCQHzsbiVdHZ7nPZ07NJAvoopdoAAcBAEekMvAN8qJTyBy4C6Ttz44CLSqlGwIdWP0SkOTASaAEMBL4QEUer3PTnwCCgOXCv1Zdc5jAYDGWN+Ahw9yluLUolG0IvUN3DFX+fws+mfj12MzZKk75T62x9FNAH+NmSzwWGWtd3WPdY7X1FH/2+A5ivlEpSSh0HQoGO1idUKXVMKXUFmA/cYT2T0xxlhrJaYiC/BAUFmUzR5Z1L56FS9eLWotQRczmZjUcj6XpT1SxZReyBXfdsLA9kF3Ae+As4CkQrpdLzhIQDta3r2kAYgNUeA1TNLL/umZzkVXOZo8xQ1koMFBRjbMo5qSn6QKbxbGxGKcWKvWe55X9/E3XpCkMDiubXo12NjVIqVSkVANRBeyLZnXxLP1WanWlVhSjPgoiMF5FgEQlOT0NfEimrJQYA3n33XVq1akWbNm2YPFlvu+3atYvOnTvTunVrhg0bxsWLFwGdkLR58+a0bt2akSNHcuLECWbMmMGHH35IQECAKRlQHkmIBJTxbGzkXGwi98/awoR5O6ju4cqSid3p3bRoDHWRhD4rpaJFJAjoDHiJiJPledQBzljdwoG6QLiIOAGVgahM8nQyP5OdPDKXOa7XayYwE3QGgdze4d+33iLpQOGWGHBt1pQaL72UZ7+yWmJgxYoVLF68mC1btlCxYkWionREzIMPPsinn37KzTffzKuvvsrrr7/ORx99xNtvv83x48dxdXUlOjoaLy8vHn30Udzd3Xnuuefy/Hc0lEHiz+tv49nYxCerj7DtxEVeHdycB7vUx8mx6AKS7RmNVl1EvKzrCkA/4ACwFkj/rTUaWGJdL7XusdrXKJ1LZykw0opWawD4A1uBbYC/FXnmgg4iWGo9k9McpZKyWmJg1apVjB07looVKwLg7e1NTEwM0dHRGQk9M4+Zngvu+++/x8nJHBEzoPdrACoZY5MdSim2Ho/ixV/38sOWUyzZdYbBrWvyUPcGRWpowL6eTU1grhU15gAsVEr9LiL7gfki8iawE5hl9Z8FfCcioWiPZiSAUipERBYC+4EUYKJSKhVARB4HVgKOwGylVIg11gs5zFFgbPFA7EFZLjGglMrXxuSyZctYt24dS5cu5Y033iAkJCTvhwxlm3hr+dt4NsQlJvPRKv2H6F3t6rDuSAQLt4VxLPISDgI/bgUnB2FMV79i0c9uxkYptQdom438GHr/5np5IjAih7GmAdOykS8Hlts6R2kkrxIDzs7OBS4xUL9+fRYsWMD48eOBqyUGmjRpwqJFizIKltlSYqBRo0b5LjHQv39/pk6dyn333ZexjObt7U2VKlVYv349PXr0yBgzLS2NsLAwevfuTffu3fnhhx+Ij4/Hw8OD2NhYm+c0lFLSUkGlgaMzpFyBoP/TFTFPb9ft5XTPJiU1jZnrj+Hp5swXa0M5G5uIALP+OQ5AB78qTOh1E/2b12BB8Cm6NapGi1rFUxrBrEWUcAYOHMiMGTNo3bo1TZo0yVJioF27dsybNy+jxMCgQYO47bbbch0zvcTA3r176dmzZ5YSA3Xr1qVly5YZOcZGjhzJI488wieffJIRGADXlhhISUmhQ4cONpUYmDFjBl9//TUDBw5k165dBAYG4uLiwq233spbb73F3LlzefTRR0lISKBhw4bMmTOH1NRU7r//fmJiYlBK8fTTT+Pl5cXtt9/O8OHDWbJkCZ9++ik9evS4kX9uQ0kk9gx83glSr8BjmyDobdizADZ+qhNuNh+qk2qWQ5btPcu7fxwCoJGPO79M6EqVii7sOHmRNnW9aJTp/Mz4nsWb682UGLAwJQYMBcX8nNiZkEW6Hg3oEgHRJ6H9WDixXlfN7PpfcCifmbcGfbyeuMRkXrmtOb2bVsfVqehT7pgSAwaDoWxwLkSXd/brpmvMdHgYbn1fV8wsx8QlJnPgbCyTBjRhYMsaxa1OnhhjYzAYSjb/7oNq/nDrB3BoOXR9otwbGoAj5/Uyd2Pf0rGEaIxNHuQ3YspQvjDL0EXAuX26Fk31xvpjACD0XLqxsX9es8KgfC502oibmxsXLlwwv1AM2aKU4sKFC7i5uRW3KmWX2DMQEwY12xS3JiWOw+ficHVyoE6VisWtik0YzyYX6tSpQ3h4OCU5lY2heHFzc6NOnTrFrUbZ5eAy/d14UPHqUQIJORNLIx93HB1Kx8qLMTa54OzsnOMpfIOh3PL3u3BqM9z/i333Tq4kwK4foJpZPktLUzhkMiqr9p9j07ELPNXPvxi1yh/G2BgMBts4uxu+7JnpfhfUss5tJ8XB5Wjwqpv9s/nl4gmYf7/er7nj88IZs5QyZWkIO09d5KdHu+Li5MBPwWG8tGgvTWt4MKFX8Z6dyQ/G2BgMBtvYOe/a+42fwtAZ4OSiz8GEroLnj0NF7xubJ+IQzB6gMwaM+gn8b7mx8UohSinCoi6z6VgkczedQCn4av0xYi4nM3PdMbo1qsoX97UvlnM1BcUYG4PBkDNJcRC+DS5Fwv4l0OQ2uOsrWPsWbPoMzu6BgW9rQwOw4SO4ZeqNzbl1JiRfhgkboWrp+cv9RgmLSuCr9cfw93Hn5+3h7A6PAaC2VwUa+bjz3kqdKeCBzvV59fbmOBdxIs0bxRgbg8GQMysmw67vr963GQkulWDANGjYC5ZPgnl3XW0/uLzgxubCUXB0gZDF0GRQuTA0qw+cIyIuiU4Nq/Lyor1sPHoho+2/fRoxoGUNmvh6kJKm+ODPQ7Sq48WQNrWKUeOCk6exERFX4C7AL3N/pdQN/vliMBhKPGGboUFPfaDSvTpUqHK1zf8WeGyz9mbCg6Fma1j/ASTGgpObTv9fOY9IvZQkCNsKR/6EzdN1rjOAgFH2e6cSwtqD53nk22DSMp2s+M/NDZm78QTVPVx5sl/jjEgzJ0d4+bbmxaRp4WCLZ7MEXaJ5O5BkX3UMBkOJITEGLoRqbyanaDBnN+ilK6xy5C/9vWcBbJ8LkYfg6ZDs0/+npcKCB+DoGki5rNPRNL0NqjeBOh3K/D7NoX/jeOLHnTSr6cl7w9uwM+wi4Rcv82Rffzr6eVO5gnOpCWm2FVuMTR2l1EC7a2IwGIqfiMOw4nmdyr+lVX+wVjvbnq0ZoL+XPwdOFXSW5tDV2nBUqnZt36hjcGiZHrvnJJ33zK14Ut8XJRfik/gi6CgLt4VRwcWRr0cHUrNyBZrX8szo07eZbzFqaD9sMTYbRaSVUmqv3bUxGAzFg1L6TMvy5/QSWFIcnNqi22plKUuVPe7V4aY+4OoJ/abAJ21h8aPg4gEvhV/b9/x+/T34f7aPX8o5+G8s474J5t/YRHw9XPni/vbUrFyhuNUqMmwJZ+gObBeRQyKyR0T2isievB4SkboislZEDohIiIg8acmniMhpEdllfW7N9MyLIhJqzTUgk3ygJQsVkcmZ5A1EZIuIHBGRBVZ5aKwS0gus/ltExM/2fxKDoRyyez4seQxqt9dRYI36QlIMNLolf6HMDyyCu+eCdwPA2oy4Eqf3ZtI5tQV2/QgIVGtSmG9R4lBKERGXxIbQSO76YiPJqWn8OqErG1/sS0Bdr+JWr0ixxbMpaJ6IFOBZpdQOEfFAGyxrUZcPlVLvZ+4sIs3RpaBbALWAVSKSvlD8OXALEA5sE5GlSqn9wDvWWPNFZAYwDphufV9USjUSkZFWv3sK+B4GQ9nn6GrwqAkPLgEHR2g1Ag7/AZ1yL4aXKxW84XKUvv53H1SqCn++Agd+u9ruUjryehWUxbtO8/SC3Xi4OeHj6caPj3SmRuXymUsvT89GKXUS8AJutz5eliyv584qpXZY13HAAaB2Lo/cAcxXSiUppY4DoejSzh2BUKXUMaXUFWA+cIfoVMx9gPTSkXOBoZnGmmtd/wz0FZO62WDImbN79HKWg3VIsOVdMP5v8O9X8DEfXAy9XtLX39wGn3WE0DXQaYKWObnemM6lgF2nogGIS0xhVKd65dbQgA3Gxlr+mgf4WJ/vReSJ/ExiLWM33zd7AAAgAElEQVS1BaxFYB63luRmi0h6LGVtICzTY+GWLCd5VSBaKZVynfyasaz2GKu/wWDITFoabP1KR45lzqwsArUCbmzsmm3g5ufBu6GOOGsxFJ4IhkFvw7AvYeS8vMco5cQlpmRcD2hR8guc2RNbltHGAZ2UUpcAROQdYBPwqS0TiIg78AvwlFIqVkSmA2+gF3TfAD4AHgKy8zwU2RtElUt/8mjLrNt4YDxAvXr1cn8Rg6EscvxvHRQAUKN14Y8vAv9ZDyhwzVTkq83Iwp+rBHLiwiV8PFx5tn9j6nqX7SXDvLAlQECA1Ez3qWT/yzzrgyLOaEMzTyn1K4BS6pxSKlUplQZ8hV4mA+2ZZM7iVwc4k4s8EvASEafr5NeMZbVXBqKu108pNVMpFaiUCqxevbotr2QwlC3Sz8Y0HQx+3e0zh6v7tYamHHEqKoE+TX24p4P5Y9YWYzMH2GJFkU0BNgOz8nrI2iOZBRxQSv0vk7xmpm7DgH3W9VJgpBVJ1gDwB7YC2wB/K/LMBR1EsFTpimZrAeswAKPRB1DTxxptXQ8H1ihTAc1gyMqRlXBTX72k5eaZd3+DzcQnpRAZf4X6VSsVtyolgjyX0ZRS/xORIHQItABjlVI7bRi7G/AAsFdEdlmyl4B7RSQAvax1AviPNU+IiCwE9qMj2SYqpVIBRORxYCXgCMxWSoVY470AzBeRN4GdXDWCs4DvRCQU7dGUD5/dYMgP8ed1hoD2Y4pbk1JPYnIqX607xv2d67P/bCzBJy6y/oguuujvUzrKNtsbyekPfhHxtPZYsg2yV0plWZYqzQQGBqrg4ODiVsNgKDoO/QE/3gNjV0D9rsWtTanm6/XHeHPZAaq5uxAZfwURaOLrwV3t6vBwjwaU5WBYEdmulArMq19uns0PwGB0TrTMFkms+4Y3pKHBYChezuwAcbg2Cs2QL5RS/Lw9nOlBRwGIjL/CvR3rMXlQUypXcC5m7UoWORobpdRg69vURTYYygJKwYaP9QFO54pwLgSqN9UlAwz55nxcIs//vIegQxE08fXgxVub8df+f42hyQFbSgysVkr1zUtmMBhKOCc3wqrXwKcFOERrr6achCAXFhfik6jo4kTImRjGf7edS0kpTL2jBQ90ro+IMLx9HiUVyjE5GhsRcQMqAtWsg5fpi46e6HQyBoOhJLLufZ1xOfIItLxThzWLQPhW3T76N506xpAv0tIUt36ynsj4K1RwdsTHw5WF/+lMI5/yGdadX3LzbP4DPIU2LDsyyWPRucoMBkNJIDpMFyoDcPOCNW9YDQIhv0KDm3Xp5rBt4H2TMTT5JPxiArW9KnDoXBznYnVC0c4Nq/L6HS2o7VV+sjbfKLnt2XwMfCwiTyilbMoWYDAYipjL0fBZIKQkXitvN1rXiTm0AtZOgxndQKVB6/KzbLZg2yncnB25IyC3lIy589vuMzzx406a1vDgpuo6hHnj5D7UMkYm39iSriZGRB68XqiU+tYO+hgMhvwQtkUbmlve0CWblz6u5f2m6NIAncZDq+G6XPOZXdC27JdbBr15/8rifaSkKdycHQuUl+zylVSm/r6fRj7upKQplu09S4NqlYyhKSC2GJsOma7dgL7oZTVjbAyG4ubkRnBwhg4P63T9q17TtWMy16Cp6A0DphWfjsXAnA0nSE5VNK3hwVPzd/HxyACOR16iWU1Peja2LTXV8r1niYhL4uORAXRuUJWgw+epWqnsZ6q2F7ZkELgmw7OIVAa+s5tGBoMhb87u1iWXQ1fp0gDpdWH+uwvSUnJ/toyz7nAEX/59lGFta/PSrc0Y+vkGxn+3HQBXJwda1q6Mv487r93eggoujjmO8+PWU/hVrUiXhlUREfo0LZvlmosKW3KjXU8COm+ZwWAoDpSCxRNh9etwbh+0H321zc0zf5U1yxh/hvzLw98G09jXgzeGtqS6hytzxnbgtlY1+WBEG5JS0th+8iLzt4Ux7IsNHI2Iz3acDaGRBJ+8yANd/Mr06f+ixJZzNr9xNYOAI9AMWGhPpQwGQw6kJMHWmXBuL7QcDm3vh5t6F7dWxcqVlDT+3P8v87eG8U9oJG3qejF3bAfcXfWvt8a+Hnw+qh0AP20Po4KzI2O6NeCp+TsZ/Mk/vDCwCWO6NSAxWSe3F4E3ft9PrcpujOpksjUXFrbs2WQu35wCnFRKhdtJH4OhdPHPh3BmJwz/BhwKslCQD/b9Citfhrgz4NcDhnxa5ssq28Lrv4Uwb8spantV4Ol+jRnXo0GGobme78d1AsDJ0YHlT/Zg0k97eGPZAVrX9eKBr7dw6UoqItp5nDU6EDfnnJfZDPkjx0Sc13QSqYGuO6OAbUqpf+2tWFFjEnEa8s2VS/CWdb550LtQMwBqtwdHW/6Gy4aoY7Dze11K+foxlIK360HlujDwLX12xizvAHD3jE1cSU3jlwldcXTI37/JyQuXuPm9IACcHIT/9vUnKSWVJjU8GdLGnF23BVsTcdpSFvphdF2ZO9G1YTaLyEM3rqLBUMrZ96v+dvGAFc/D7P6w6bOCj/fXazpEOXRV1raYcEiKhQ7joGEvY2gycSbmMn5VK+bb0ADUr1qJoQHaqAxrW5v/9vVn0oCmxtDYAVv8/klAW6XUGKXUaKA9uo6MwVC+CZ4N1ZvBswf0/gnAli8hNfnGxg35Nass4pD+rt70xsYuY6SlKc7FJlKjcsHPvnx4TwDrn+/NG0NbFqJmhuuxxdiEA3GZ7uOAMPuoYzCUEs7s1Cn6Ax/SJY+Hz4J75+v9lANLCzZm9Cn9feA3uHzx2raIA/rbp1nBdS6DRF5KIjlVUcvLrcBjiAh1vSua/Rk7k6OxEZFnROQZ4DRXy0K/hi4LHZrXwCJSV0TWisgBEQkRkSctubeI/CUiR6zvKpZcROQTEQkVkT0i0i7TWKOt/kdEZHQmeXsR2Ws984lVijrHOQyGQiN4tk7T3+aeqzL/AeDdEDZPz/v5M7vgx/tg1w9w4Sikpenvel0hOQG2z722/7n9UMmnXIc1Z8fZaJ2mp+YNeDaGoiE3z8bD+hwFFnM1/HkJcNaGsVOAZ5VSzYDOwEQRaQ5MBlYrpfyB1dY9wCD0+R1/YDwwHbThAF4DOqGDFF7LZDymW33TnxtoyXOaw2C4cRJjYO/P0PIucKt8Ve7gAJ0mQPg2nfQyN/YvgUPLYPEE+LQdTK0CV+KgxTC9+b/6dVg1RYc67/kJdv8IDXrY9bVKI2djLgNQs3LBPRtD0ZBbIs7Xb2RgpdRZLKOklIoTkQNAbeAOoJfVbS4QhN4DugP4VunwuM0i4iUiNa2+f6WXoRaRv4CBIhIEeCqlNlnyb4GhwIpc5jAYbpytX2nvo+MjWdsC7oM1b8KW6VC3Q9b2dKKOQpUGcM93cHqHDiyIPKyXydqMhJUv6bDqwyshIUpHuQ25geCDMsoZy7Mx+cpKPrkto31kff8mIkuv/+RnEhHxA9oCWwBfyxClGyQfq1ttrt0LCrdkucnDs5GTyxzX6zVeRIJFJDgiIiI/r2QoD4QH66WtzFy5BJu/gEa3ZF9O2dUd2j0AIYsh5rReLnu3oU4vk5kLR6FaY6jRSmcAmLARHvoT/LrrLAB3fAb3LdSGJv5f6PuqOVOTicTkVJRS/H04ghqeblSpaCpjlnRyOxCQnv/s/Vz65ImIuAO/AE8ppWJzSf2QXYMqgNxmlFIzgZmgz9nk51lDOeBrqxjtlJirsu3fQMIFnb4/JzqO157Kh82vyn55BBr0hNjT+tR/1DF9n46jM9TrdO04jQfAY5t0SprMfcs5G0IjGf9tMHd3qMu6IxE80cffpJQpBeS2jLZdRByBR5RS9xdkcBFxRhuaeUqp9HjOcyJSUyl11loms6o+EQ7UzfR4HeCMJe91nTzIktfJpn9ucxgMthGX6dxyShI4ueqDlVtmQP3uWQ1DZqrUh5tfgL/fuSqLPKTHdHKFQ8u1zLth3npU9DaGBgg9H8+KvWe5ycedpxbs4kpKGnM2nADg7kBTirk0kGvos1IqFaguIi75HdiKDJsFHFBK/S9T01IgPaJsNDrgIF3+oBWV1hmIsZbAVgL9RaSKFRjQH1hptcWJSGdrrgevGyu7OQwG2zi75+r10TU6WuzMDh2eHHBf3s/3fglG/aKvuz0JL56GF0/BY5v1IVDQy2iGPPlj37/c9sl6PvjrMI/N24G/jzsPdK4PQGD9KtSpYpYXSwO25NU4AWyw9mkupQuvMyDZ0Q14ANgrIrss2UvA28BCERkHnAJGWG3LgVvRYdUJwFhrnigReQNID++Zmh4sAEwAvgEqoAMDVljynOYwGGwj8x7LjyPByQ1c3MHBCZoMsm2MRn1h1M96H8bZ2sCuVFUfAj261ngsNhCTkMx/f9xJ81qejAisw9bjUUy9oyWh5+P5bvNJbjcn/UsNeeZGs87WXI9SSk21j0rFg8mNVk7ZvwR2fAv3/aRDl4/8Baun6nQwSfEwYo4OFIg6pjf1awVALxNJX1Qs33uWx+bt4KdHu9DB79ozRuuPRNC5YVWcHe2cANWQK7bmRrPFs9mvlPrpusGNp2AoGyyfBPHn4MQ68G2lz71csiITe7+iI86yizozFAnrDkfg4epEQF2vLG09/G2ruGkoGdjyJ8GLNsoMhtJH9Sb6e/tcWP4cXI4G//56X6XDuOLVrZyz/0wsv+85S4/G1Yz3UgbI0bMRkUHoPZTaIvJJpiZPdHYAg6H0k2DlIEtPftnnFej2lM5NZlLDFBsnIi/x4OyteLg58fJtzfN+wFDiyW0Z7QwQDAwBtmeSxwFP21Mpg6HIiDurU8Qc+1uHLHd7WteScc/2HLChCIiIS+L+WVtIU4rvxnWmtskOUCbI7ZzNbmC3iPgqpa7JCmgl1fzY3soZyhGpyaDS9DkUW0iM0YXGWt4FHjW0TCmd4j/qGLS+Wxca8/DNeYyUK5AQqcsEDPg/fXK/oIXPDIXGR6sOcy42kV8mdKWRj3txq2MoJGxZCB2ZjWxMIethKO8sewberq9T9+dFWirM6q/zh/2eycmOOgZ/vABbv9Sn/6d3gSsJuu1YEEzvfm3q/vhz+tujBnjWBJdKhfY6hoJxLjaRhcFh3B1Yl9Z1sgYFGEovueVGu1dEfgMaXJcXLQi4UGQaGso+VxJ0+HHKZR12nBmlrn4iQ7WxOLoWIg7qQmKHlusKl2mpVw3VqJ91SpiEC7DvZy1b/wGc2wsHfr86dnqWAI+a9n9Hg038tvsMyamKh3vYkF3BUKrIbc1gIzprczXgg0zyOGB3tk8YDPklLU2ngAHwqKUrUh5aAX49dFLLhQ/ApQv6bMu3Q3Q/B2eo4A0Pr4Y/X4YNH8GFUPCsBY4uumxyo35weqfO0Fy/Gxxfp59d+jikJUO70brQGVxdhjPkSVJKKq5O9ikylpqmWLr7DC1re9KgmvEyyxq57dmcBE4CXTLLRaQb8Akw0b6qGco8JzfByhe1R1K/mzYSa6fpE/sth8OdX+mqlQC/WGHIfV+D6JNXjdHtH+s9lz8mAwpqtdVJLUGHLi97BtZbyS7aPQg75+mlt70/W1kBPGzLUWbgj31nmfjDThY/1o1WdSrn/UA+SEpJ5YFZW9kTHsPrQ1oU6tiGkoFNwesiEiAi74rICeBN4KBdtTKUfZY9B3MGQtw5GPYljP796pkX0Mtf6969en8pArzqQ49ntIFpNfxqW+dH9Ul/Rxeol+lvo9Z3a2Oy63uoWBVu/wT+XyQMnQ7/7oWjqyFwrDZahgwSk1PZEx5NaprOLhKdcIV5W07yzMLdpKYp5mw4XqjzXb6SyqSf9rD1eBRvDWvFg13qF+r4hpJBbudsGqODA+5F79EsQKe36V1EuhnKKvuXwLavoMMjcMvUq3VaMiemrNMBgv5PX/v3hyN/5u6BtBimSyq7elyVuXroQmTbvtLjiehPwH3aM9rxLXSeUPjvV0pJS1PM3xbGW8sPEJ+UwnvDW5OYksbU30JITlU08nGncgVnft97lsFtatKnaS6RfjaglCL0fDwTf9jB4XPxPNe/Mfd1qldIb2MoaeS2Z3MQWA/crpQKBRARc77GcGMkJ8LKl6FGaxj49rWhxunGpJKP9nZmdNfh0O3HamPjnMd5i+zCnDs8DNu+vtbjAfCqC31evrF3KUOEX0xg4g872R0WTacG3mw5HsVf+88RfPIibep4MWVIC1rU8iQy/goPzNrCMwt3s+OVW3BwKFgdmcTkVPq8H8SZmESqubvw7UMd6dnYpJ8py+RmbO5CezZrReQPYD7ZFywzGGxn1zyICYOhX2Q90+LkqhNi+jaHynX0ns3F43qzv+N/CuaF+DSF8Wt15JohR2b8fZSDZ2P58J42DA2ozTMLd7No52kAPr23LS1r6z2a6h6uPNyjIc/9tJvD5+NoWsOzQPOFnInhTEwiHf28+ey+tvh4uhXauxhKJjnu2SilFiml7gGaoouVPQ34ish0EelfRPoZyhqnd2jPJaf0+o37a0MD0GwwdH0CnFzg1nfBu0HB5qzVNm+vqJyz7nAkPfyrMaxtHUSErjdVBaBTA++M63Q6WtmXt524mGUcW9l5KhrAGJpyRJ7HpZVSl4B5wDwR8UbXhpkM/Gln3QxlkcjD1wYCGIqdoxHxnIpK4OEeV435sLa18XBzpk9Tnywll+t6V8DX05Wv1h3j35jLdL2pGt0aVbN5vmMR8czZcIKald2MoSlH5CuVqlIqSin1pVKqT159RWS2iJwXkX2ZZFNE5LSI7LI+t2Zqe1FEQkXkkIgMyCQfaMlCRWRyJnkDEdkiIkdEZEF6NVERcbXuQ612v/y8o8GOKKWNTTX/4tbEYBGbmMy4b7bh5uxA32ZX97ycHB0Y2LIGLk5Zf0WICM/2b0LlCs7M+PsYo77ewu97zmTplx0hZ2IY+vkGTkdfzrZsgKHsYs+83d8AA7ORf6iUCrA+ywFEpDl6f6iF9cwXIuIoIo7A58AgoDlwr9UX4B1rLH/gIpCeD34ccFEp1Qj40OpnKAlcioDEaKhWdjybjUcjWbQzvLjVKDA/bjnFiQsJzB7TIV8JL+8OrMtvT3Rn35QB+Pu4M2XpfgZ+tI5Xl+zL8Zkj5+J4YNZW3JwdefnWZrx0a7PCeAVDKcFuWQeVUuvy4VXcAcxXSiUBx0UkFOhotYUqpY4BiMh84A4ROQD0AdKLwc8FpgDTrbGmWPKfgc9ERFReJUkN9udciP4uI55NXKIuWRybmEKfJr5Uruhc3Crli9Q0xdyNJ+jSsCpdb7J9GSwzFVwceem2Zrz5+35cnBz4dtNJjkdewslBqObuylt3tuK7TSdxdhQ+XROKo4Ow8D9d8DMZAsodBTI2IrJBKdWtgHM+LiIPossXPKuUugjUBjZn6hNuyQDCrpN3AqoC0UqplGz6105/RimVIiIxVv/IAuprKAwuX9RVMSt4Q+12xa1NofD52qNExl8B4Pe9ZxjVqXQdRlx3JIIzMYn8v8E3Vi+mdxMfejfxISU1jRd/3UvImViSU9NYeyiC9vWrMPX3/QBUqejMAmNoyi0F9WwKevJqOvAGoKzvD4CHyD6kWpH9Mp/KpT95tF2DiIwHxgPUq2cOk9mFyCO6Zsz6D+DiCRi9FCpUKW6tbphTFxKY/c9x7mxXm5DTscxcd4xftofz8m3NaF/f/kXXvtt0gkU7T/PTo11xdBDik1JYtCOc2MQUHut1EyJCYnIqrk4OGRv8SuncY7GJKfwbc5lV+8/jXcnlmr2aG8HJ0YH3RugS2ldS0uj41iom/7oXgFtb1eCJPv409vXIbQhDGaagxqZAS1JKqXPp1yLyFZCegjccqJupax108TZykEcCXiLiZHk3mfunjxUuIk5AZSAqB31mAjMBAgMDzTKbPfhpDJyz1vHv+ALqdy1WdQqL/1txAEcH4YWBTdl5KppHv9/OyQsJTP1tP0se727XuZVSfLX+OKeiElh/JIJNRy8wb8sp4pO0o//eykM08fUgNCIerwrOBNT1YkhALXw83Hhy/i4AHB2EWl5uPNnXP9sggBvFxcmBu9rVYdY/x2ni68EXo9oX+hyG0kVu6WruzKkJKNChBRGpqZQ6a90OA9J3E5cCP4jI/4BagD+w1ZrLX0QaAKfRQQT3KaWUiKwFhqMPm44GlmQaazSwyWpfY/Zrigml4OJJfd3vdWg7qnj1KSRW7D3Lin3/8nS/xvh6ujGghS+TBjTh0L9xLN19hi3HLtCpYdW8ByoAKalpzNtyilNRuk7PmDnbABjSphb3d67P3V9uAuDQuThua12TCs6ObDsRxZPzd+FdyQWANc/eTD3vijg52jM+CF66tRl9m/lQt0pFu85jKB3k5tncnkvb77m0ASAiPwK9gGoiEg68BvQSkQC0Z3QC+A+AUipERBYC+4EUYKJSKtUa53FgJeAIzFZKWbvMvADMF5E3gZ3ALEs+C/jOCjKIIvvib4aiIP4cXInTaWnKSA6ypJRUnv9lDwF1vXi0l06vIyJM7N2IxORUNh6N5LO1oXYxNn+G/Mubyw5wKiqB1nUq07+5L0t2nWFo29pM7N0IgGX/7U7s5RQ6N/TOWD67kpLG2G+2siH0Ak18PWhYvWgSjzo6SIEDDwxlj9xKDIy9kYGVUvdmI56VjSy9/zRgWjby5cDybOTHuBqxllmeiD54aihq9i+BExt0Usy6na4un/m2LF69CpHdYTHEWfsi19d1cXN25OEeDXl7xUF2h0XTphDPkaSlKZ5duBvfym7MfKA9/Zr54uAgPN7n2si+FrWypv53cXLg45Ftuf/rLfznZlNOwVA85LlnIyKu6Dxpfpn7K6Wm5vSMoZyQlgZH10CdQKjgBWv/DyIO6LLMVfy0wQHwLZ31SWIuJ+Pq5ICb81WjsvnYBUSgY4PsgwDu71yf6UFH+WxtKF89GJiv+dYePM9rS0P49bGuVHN3vabtWOQl4pJSeLVnQ/q3yH+xt2rurvzxVA4pggyGIsCWRdsl6LMrKcClTB9DeSbiEHxzK8y7CxbcD+cPaEPT41kYNlOHOu9ZoIuiVbR/dJY96PHOGu74bEPGfVJKKqsPnKNpDU+8Krpk+4y7qxNju/nx1/5zLNwWRlxiss3zzVx3jFNRCcz6J2u9mL2ndS6x1nXMqXtD6cSWaLQ6SqnsMgEYyivBs2H58+BSSVe/3PEtfNFZtzUeCHU76pLLq6ZAz0nFqmpeJCanEnXpCrWs0/OR8Un8vvsMfZv5EpuYQmxiHI//sINTUQmEno8n4Uoqb9/ZKtcxx3T149M1oTz/yx52h0czbVjW/mFRCSzYFqZDp8/Esic8ms3HLwDw9fpjeFd0YVTnelR00f+L7jwVjZuzAzdVN2dUDKUTyStQS0RmAp8qpfYWjUrFQ2BgoAoODi5uNUo+x9fB3Nuh0S264qV7dQgPhmXP6vM0T4fossxpqboaZq2A4tY4Vyb9tJuftoez69VbcHN25J6Zm9kdFs3QgFos3qWj6X09XfH38cDf153eTXxsqruy/kgED8zaCkCr2pV5pn9jejfxyWiftmw/X63P6sFM6HUT+8/E8vfhCLwqOnN/p/pEJVzhhy2nuLlxdeY+lGWb0mAoVkRku1IqzzVjWzyb7sBYETkGJKHDkZVSqvUN6mgojRxdCw5OcM93V9P21wmE8UGQfFkbGgAHxxJvaAC2ndBHsOZvC+Pg2Vh2h0Xj6CAs3nWGau6ubHu5b5asx7bQw78600e1Y8K8Hew9HcPYOdsY1akekwc1xcPNmQNn4wB47fbmtKtXhbMxiTy7cBfD2tbm+QFNCD55kZnrjvF5UChKwegu9Xl2QNnJKWcof9hibAbZXQtD6SA8GMK2QvVmWevDiFwt71yKqGAtU72/8hApaYpnb2nMguAwwi9eZkzX+gUyNOn0burD3YF1GNmxHiv2nmXWP8dZe/A80+5sxd7TMdzbsR5ju+m0/m3qwoAWAzLm6+DnTQc/b45FxLP3dAxD2tS6IV0MhuImt0OdbsCjQCNgLzArUy4yQ3kj+hR83Vdft7kv976lBKUUYVEJDGpZg5MXEmhRy5PH+zSiaU1PftkezvieN93Q+G7Ojrw7XKdvaVevCre2qsnzP+9hrHUQs3Wda8OUszMmDau7F9m5GIPBnuTm2cwFkoH1XE3x/2RRKGUogRzIdI63StElnNwYGsmC4DDu6VCXau6uNKrujoODsO90DK5ODvhfl2tLKcWOU9GEX0zI0xuITkgmPimFQD9vvhjVLqPvLc19uaV54eQLy0zbelX4/b/d+WxNKD8Fh9PNHHg0lCNyMzbNlVKtAERkFjp9jKE8ohSE/KqvK/lAsyF2nS4uMRl3VydS0hSP/7iTqEtXWHPwPHGJKbSt58WEm2/isXk7SElTvDe8NSMCdfq8xORUhs/YyL7TsQDU8qpAB6uEsVKK83FJ+GaqDJme8qVulQpFtkTl6uTIs/2b8Gx/s/9iKF/kds4m44CAWT4rh1y+CEf+0lFlQW9D+Da47QOYdAR8bywlfXbsPxPLI98GM23Zftq/uYq+//ubV5fsI+rSFVrW9iQuMQVfT1fCohIY/912UtIUtSq78c4fBzkbcxmALcej2Hc6lqf7NaaSiyMLt12tTvHtppN0ems1S3adJiklFYCQM9oo1ata+vaaDIbSRm6eTRsRibWuBahg3adHo3naXTtD8fDXa7D5C0i9Ao0HweEVEHA/BI7L+1kbuHwlldPRl/Gq6IxXBR299vgPOzgWefWscAVnR37cGoanmxP/uzuAWz9ez8TejRjatjbTg45S37sizWt5MmLGJnq/H8ToLn5EJyTj4ujA+J4N+Tf2Mot2nua5AU3w9XTj200nAHhy/i4cRHs9MQnJtKztib+PSXtvMNib3HKjOebUZijDxJ6FDR9pI3PpvDY09bvB4A91xFkh8Oj32/n7cETGfSUXRy5dSWVgixr8EdMdtCMAACAASURBVPIvtSq78fsT3Tl0Lg6loLGvB+ue703Nym6I6LT+6ax65mY++PMQM9cfQyno0rAqFVwcmXBzI34KDufj1UcY3cWPoxGXePaWxtSo7Eb4xcscj7zE+bhE3hzaEkcHE+VlMNgbu5WFNpRSDi3T3/2maM9m46c6a7NT9ulZ8suG0Ej+PhzB/Z3r4e/jwcWEK0QnJONZwZkxXf3468A5evhXR0RoWuOq85x+wv966npX5KORbZnYuxGzNxxngJU3rF7VitzXqR7ztpzCyTImd7Wvk+M4/7+9ew+vqroTPv79nX1OTu43EkJICNeICoJACshYxmpVvFun7VR7sWpr69R525m+M9Vpp3amN6tv57GttaPT2oq2WlulY6sWqYpUEBFQuQgYLuGShBByv53b3uv9Y++EBBIgISc5SX6f5znP2WedtddeK5f125e191JKxZcGG3WMY8Pbv4bc6ZA/0z2S+bv/GdRN/GlLFRnJfr5x1bk9HnDZafmtCykd3/+hvqUFGXz/hp73Gf/jxaX8ftMhlr+xn0m5KRpolBpG8Z09SY0s638GVZvhb782aKfMjrexooEFk3N6DTQAfzMjj/HdRoydifyMILdd6N40uWhqfCYzU0qdHg02ynW0HF75Nsy8CuZ8fNCKfWL9fu5fuROApvYo5UdaKZucM2jln8rtS6fxgSk5XH9+0ZBtUyl1orgFGxF5VESOiMi2bmm5IrJKRMq99xwvXUTkxyKyW0S2iMj8buvc7OUvF5Gbu6UvEJGt3jo/Fu9Gib62oU7CseEPd7iPoBnEgQAA3/jDNn766h6MMfx1tzsoYP4QBpuM5AC/++ISLizVGyiVGk7xPLL5FXD81AR3AS8bY0qBl73P4D6hoNR73Q78DNzAgTud9CLcWTnv6RY8fubl7Vxv2Sm2ofqy5xX3PprLvw8Zg3fnfE1zqGu5oq6de1/cyYzx6V03Wiqlxo64DRAwxqwRkSnHJV8HXOQtPwasBr7mpS837nwH60UkW0QKvbyrjDH1ACKyClgmIquBTGPMG176cuB64MWTbEP1peJ18AXg3OvOqJinNhzgNxsOEI46BPxC2eRjQeWrT7/DoYYOnrp9MQFLz94qNdYM9X99gTGmGsB775zgowg42C3fIS/tZOmHekk/2TbU8er3wp/+yb2vpmj+GT+1+ddvHqC6KcSUvFSOtkT41boK0pLcgQCbDzRyw/wiFk/TC/VKjUWJsovZ20UCM4D0/m1U5HYR2SgiG2tra0+9wmiw83n3Cc7GwJM3urNuAhSdcu6jk7IdQ/mRFq6dO5GHP13GLz5bxlVzCnnxy0vJSw+SlRLg3648ZxAaoJQaiYb6PpsaESk0xlR7p8mOeOmHgEnd8hUDVV76Rcelr/bSi3vJf7JtnMAY8wjwCLgzdQ60USNG1dvw1E1gJbmnzGp3ujdshprc6Z37KRS12XW4BZ8I6cl+QlGHmd5TmGdNzOKnN7njPO655lxy05LISw8OanOUUiPHUAeb54CbgXu99//tln6niDyFOxigyQsWK4HvdRsUcBlwtzGmXkRaRGQx8CbwGeAnp9iG2vk8iA9mfQS2/g78KXD+TZCcdep1u3lxazUPvrqbXYdbiDlujC7OcW+YPGvCic8Zu2buxDOvu1JqRItbsBGRJ3GPSvJE5BDuqLJ7gadF5DbgAPAxL/sLwJXAbqAduAXACyrfBt7y8v1n52AB4A7cEW8puAMDXvTS+9rG2GaMOydNyRK44RH44Fch3NLvQLN+bx1f+s1mzirI4Pal05hTnMWa8qP85s0DAAO6+18pNfrFczTajX18dUkveQ3wpT7KeRR4tJf0jcDsXtLretvGmLfnFajdAdf8yP2c3/d8Kg+t3s05hZl8aOaJYyueWL+frJQAz/7DElK9KZUvnzWBpaX5tIVjpAX1CUhKqRNpzzAWGANr7ofMIpjb1z6Aq6qxg/v+vAuAzf9+Kdurmjh/UjYiwhce38ja3XV8anFJV6ABdzrjZbMnxLUJSqmRTYPNWLB/LRx4A664D/wnv0j/x3erupav+cnrVDZ2ELCEidkp7K9rJzXJ4saFJfGusVJqlNFgMxa8dp87nfMpRpy99n4tP3llN2WTc0gN+lnzfi3zS7L5wJRcXt11hH/68Fl8+cOlQ1RppdRoosFmtNv/Bux7DS77jvvssz78+s39fPN/tzOzIIMHb5pP+ZEW1rxfy5c+NINLzingbr1HRil1BjTYjHSOA74+7s1tr4cVX3Cv1ZTd2mcRr5cf5esrtvGhmfn85Kb5pAf9TMhKZt1dF+scMEqpQaHBZiQzBpZf6y7//eOQ0u1pyo4Dz94OzVVwy4uQlNZrEc+9W8U//fYd8tKT+O9PLyDoPzbPjAYapdRgSZTH1aiBeP/PUPFX9/XLK6G5+th3a+6D3avginth0gd6Xf2192v5P0++je0YblpY0iPQKKXUYNJgM1I4Ts/P7fXwwr9C7jT41DPu884evQx2vwxbf+8OCpjz91B2W6/FhWM2X1+xlWl5aSy/dSFfunjGEDRCKTVWabAZCdY9CPdPh23PQDTknSL7PLQehr/7Ocz4MNz8HIRb4Ykb4JnbwNhw2Xd7nQitORTlW8+9x6GGDv7julksPStfj2qUUnGl12wSXbgFXv0uRNvh97dCIA2yS9ynAVz1X1C0wM1XtABuWwXlKyEWgpypkJ7foyhjDI+tq+BHL5fT0B7l5gsm88HS/F42qpRSg0uDTaLb+js30Hz2Bfd914tQuckNNMePMMub4b768B9/fI9fravgwhl53HXF2cwu6t9z0ZRSaqA02CS67StgXClMXuKeEiu9dEDFVDZ28Kt1FXxyUQnfuX420svpNaWUihe9ZpPImg65UzbPur7Xay/90fkYmi8sna6BRik15DTYJKpoBzz/VXeis3mfOqOintpwgP9a9T4LJudQMu7Mpn5WSqmB0NNoiaajAQ6shxe/Bo374fLvQ86UARe363AL33xuO2WTc/jhx+cOXj2VUqofNNgkCmPgxX+FDY+4n/Nmwmeeg2l/O+AiKxs7uOWXG8hMDvDjG+fptMxKqWEzLKfRRKRCRLaKyDsistFLyxWRVSJS7r3neOkiIj8Wkd0iskVE5ncr52Yvf7mI3NwtfYFX/m5v3cS/SFHxuhto5t4I1z0Ed6w9o0BT1xrm0794k5ZwjOW3LtRAo5QaVsN5ZPMhY8zRbp/vAl42xtwrInd5n78GXAGUeq9FwM+ARSKSizvVdBlggE0i8pwxpsHLczuwHnfK6WUcmzY6MZWvBF8ArrwfghmntUrUdnhi/X52HW4B3DEEmckBrp9XxL+t2EplQweP37aIcydmxrPmSil1Sol0Gu064CJv+TFgNW6wuQ5Y7k0dvV5EskWk0Mu7yhhTDyAiq4BlIrIayDTGvOGlLweuJ9GCjePAke0gljsIYNefYfIFpxVobMfwXlUz//3aHp7fWk1eehCfd+zW2B7l4TV7Abjvo3NYODU3nq1QSqnTMlzBxgAviYgBHjbGPAIUGGOqAYwx1SIy3stbBBzstu4hL+1k6Yd6SU8sW34Lf/hiz7QLv9JrVtsxHKxvpzUc41BDOyvermTl9hqAEyY0O1DXztL7XwXghnmJ12yl1Ng0XMHmb4wxVV5AWSUiO0+St7frLWYA6ScWLHI77uk2SkqGeKrjnX+CjImw7PvuMOfx58DE83vN+sBf3ucnr+zu+uwT+HhZMalJfr70oek98paMS+WPd15ISpIPv6Uj25VSiWFYgo0xpsp7PyIiK4CFQI2IFHpHNYXAES/7IWBSt9WLgSov/aLj0ld76cW95O+tHo8AjwCUlZX1GpDiIhaBvavhvI+5N2yeRGs4xmPrKpiWl8a/XD6TSbmplIxLJTM50Oc65xXrY2iUUollyHd9RSRNRDI6l4HLgG3Ac0DniLKbgf/1lp8DPuONSlsMNHmn21YCl4lIjjdy7TJgpfddi4gs9kahfaZbWYmhciNEWt2nNZ/CI6/toTkU44cfn8sV5xUyuyjrpIFGKaUS0XAc2RQAK7zRyH7gN8aYP4vIW8DTInIbcAD4mJf/BeBKYDfQDtwCYIypF5FvA295+f6zc7AAcAfwKyAFd2BAYg0OOLjBfS+5oM8sMdvhhW2H+dlre/jIvCLmleT0mVcppRLdkAcbY8xe4IRb2Y0xdcAlvaQb4Et9lPUo8Ggv6RuB2Wdc2Xg59BbkTqPZyiTVdvBbPjoiNsvfqGDn4RZawzHW76mjJRxj7qRs7rnm3OGusVJKnZFEGvo8NhgDh96iIusDXPStlwDISgngE2hoj1KYlUyS38fVcwv5YGk+F589nuSATmymlBrZNNgMtdfug9YaHmmbxpziLD40czyN7RGaQzE+Mq+IpWfpZGZKqdFHg81Q2r4CVn+PA5Ou4zfli3jmmlksmKzXYpRSo5/eiDFUqt6GFXdA8UJ+mnYnOalJnD8pe7hrpZRSQ0KDzVBoOQxP3gRpeZi/f4LVe5tZMiMPy5f4zwdVSqnBoKfR4skYiIXhyRsh1AS3reTlg1DTHObScwqGu3ZKKTVkNNjES9tRePx6OLzV/fzx5UTyZvHA79ZSnJPCVXMKh7d+Sik1hPQ0Wrz86SvHAs3EeXDudXz3+ffYVtnM3VecQ0CfW6aUGkP0yCYeQs3w/kpY9EXImADnXs+zmw/x2Bv7+dyFU/WoRik15miwiYfyl8CO8PDR8/ClLWFJKJe7n13Hoqm53HXF2cNdO6WUGnIabAZbez288h0iaRP5wfYsnO07AJiQmcyDN83Xx/4rpYZFKBaivKEcv8+PbWwykjJID6TTHmtnXPI4UgOpcd2+BpvBZMfg97dC0yF+PuVH+Jv8fHJRCRv21fOd62eTnxEc7hoqpUaJpnATaw6toaa9ho5YB6FYiI5YBx2xDmraa6hurUZESPIlYfksKpoqiDiRXst6+MMPs6RoSVzrq8FmMP3lHtj7KtErH+Bnz+dx7dwJ3HPNrOGulVIjSl1HHbsadpEeSCc9kM6GwxtYMnEJJZknn+Aw5sSo66gjJZBCxI6Ql5I3RDXuKRQLUR+qpzHcSFogjc01m0n2JzNv/Dzao+20RFtojbRS1VbFltotRJ0o+Sn55KXkEXWiNIQaqGytpD3aTrI/mRR/Cin+FJrCTYgIbdE2jnYcZW/TXmJODABBSPGndOUfnzqeOflzEBGidpSIE2FR4SLmj5+PiGCJRUukhZZIC6mBVKZnTz9Fq86cBpvBUr8P3ngQZ/5n+a1zMS3hbVw7d+Jw10qphGM7Nu2xdtID6QDsadzDpppN1LTX0Bhu5NnyZ7GN3WOdnGAOnzj7ExSlF7G4cDEFae59aqFYiIfeeYiX9r/E4bbDPdYrTi8mLyWPxnAjITvERcUXcee8O8kKnvnkgvub9/NSxUsYDD7xUdtey56mPext3EttR+1pl5MdzCYtkMbR9lpi0TA+B1JIIjcpmwnBPJoiHRyNholEOsj0pWIZSPelMjeQxVXJl7Ewv4zi1EL8toBjY2I2xo5BLIZp8pZtGxONYapjsKPKzROLgR3z8h8h+/rzIe2MfywnpcFmkNg7X8ACrtq8gB2hbUwel8qS6eOGu1pKDbuYE6Mh1MBbh99iTeUa1laupTHcyIzsGdSH6qkPudNQCYJPfFw19Uqum3oN4XA7zR0NZEoqT2x9jN/+9SEsB35qw4z0KaT5kjncXEVbRzNL885nUuoccgNZhMPtWA7s27ebWKSZDF86xk6m/PWneGjFS3z+nFsQ28HEYsc6ZttxO2vbcTtnp/PdBtvB2DZRO0Ik0sHh5ir21O0iyTFYNlgOZONjnqSQKkGCkkfA+PA7EItGSJEknFiUWCSMzzH4HIPYBrFtxG7G2A1gdw+uHd6r+jR+us+dVq6TsixSFywgacqUMy3ppMSdLkaVlZWZjRs3Dnj9xocu5fDhan4yczlXzynkwtI8MhJ0Rk3HOFS1VmGJRWF6IcYYajtqSQ+kx/0ioXKVN5SztnItls8iO5hNTnIOkzImsat+FzEnRmu0leL0YooyisgIZBAwPtKsFIjFcGybvfXltISaOC9nFuK4nSG23eP9xDTH3Zu1O/ds3XcTs4/t5XZ1wN2WO/eMO5eP3zM+brlrfdvGiUbYVvMu0WgIy4Yk/GRYqSQbP+3hVoKORTJ+Arbgi9mYaBQTjbpP3xhKfj8iApaF+HwYnxDBJiYOERMjJg6OgOMD2wfJSWnkZ0zAH0jC+C0sfxJiWeC3EH/g2LLlR/x+xG+B5UcsCwn4j1vuzGe59ehctryyOpct/wn5xe+V5be8bQaOLXv5u5Z7ze+1+wyIyCZjTNkpf8RntJUEJiLLgB8BFvBzY8y9cdnQoU0421eQfWQDj/k+wQ8/Pvek88+0Rlp5YPMDtERaOCf3HFIDqVhiMT51PIsKF5FkJZ3WZqNOlIMtB7tOSbxd8zabj2ympr2GnGAOqYFU8lPyCfqDZCZlUpxRTMSO8Pv3f8+Ouh2E7BCCkJOc03VRESAtkMZ5eefxlflfYVbemV9vMsZQ3ljOzvqd7Gvax76mfdiOzTXTr2Fy5mSCVpCgFSQrmHXagc4YA50dbKxb59mj03W6Tisc22M9fg/WWzfabQ831tlpRo91sl2daawrr/HyVjYeoLmtnokpE/A7bmcqnfXq7HxjMcLhdkwsirFtmtrqONJSTYEDfht8DtgOHHAgwwHLhgLjvjc70O70/nNIBfac8W+oH3w+t7Pyex2l39+jQ3V8QogoYlkEkpIRf4DacB0hO0RuRj4FGRPJSM12O9+uzjaAJAWQQFK35YC7DX/A66i9TrZ7Wmen25kW8Hsd6bEOuquuXn0dy8dnV93K3rYD2D5ICiQzKWcqdy/+Nw6311DRXEFLpIW2aBsrK1bSGg1TnF7MvPHzmJA2gaxgFplJmZTmlDJr3Kwz7qTHmlF5ZCMiFvA+cClwCHfq6BuNMe/1tc5Aj2x2/M+t5Fev4A2rkD9N+zq3XVRKzIkRdaK8dug1th3dRnVbNbZjuxfrnChRO8q4lHHUtNf0KGvWuFl84uxPkBPMwe/z4xMf7dF25hfM59c7fs3qg6tpjbbSFm2jJdLS4/y0GMPktBIKUwpoD7fSHm6hJdRILBolGgvjM26nVpRSwAXjFzE5bRINbUdpaK8lmSQKgnlEIh00tdfzbvUmwpEOlk26jCOt1SwZv4gpacV0hNp4q3I9xamFlKQUde0ZYx/rhJvbG6hpquRoSw0t7Q1EIyGikQ4sB/y2kO5z987taATLMVhe5+o3Qo4/k1QJuueubQef1xlbRrCjEcTxeuVYrN+/p8FmRLB9EPMZbJ+7xxvzgbF8BIOppCSn0+6ECYtNi9Pm7iVb4PiEmA9y0vIozZuJL5BEVGw6TJRGu4XctHysQBLJwTRanA5anHZCJsru1n1UdRwmMzWHgoyJTMwsJuYzrK5cQ5sJde11OwKTsqfwmfM+S3baODdAWH7E8oHPojZ8lD2t+wkRIyIxJmQWMadgHoFg8rE9Xa9z7rHcucdvDG3RNpoiTRxsOUhzuJmmSBPbj27n+b3PE7JDJ/yszs49m6evfjohOue6jjper3yd2o5aGkONrNi9guZIc9f3Kf4U0gJplGaX8o3F3zjloAR1+kc2ozXYXAB8yxhzuff5bgBjzPf7Wmegweb/ff9mnPfeIhiDYNQ9f9vZsfvxkRvIJsUXxGdAHIM4DjmBbDL8acSiYe90R4z2SBtHW49gHBtfZxleOT7jlpuEH8uAeOlueW6ZicAWsC2303UsQfx+jN8iKZhKMJjq7u0GAmBZdBAlKo7bUVtCk91GZUc1UZ/p6rhtyy0zkJTsdqg+wPKTnpxJBJtJOZO5sORvsfxJGJ/g+MD4fPgsi+SkNPf0g8/q6mh7fPY64K7TCoFjHWyYGBuPvs0fKv7Iu/XbiFnuqZPOl7F82GKYnjWdW2bfwrzx87h/4/1MyZxCdVs1qw+uJmyHEYT8lHzKJpQxf/x8kqwkRISi9CIWFCzAJ/2758oxzgnrtEZaefvI29SF6miLtlEfqufx9x7HGMMNpTcwKWMS4F7QXle1jgMtB04oNyMpg68u+Co3lN7QFRAqWyvJSsoiPcm9iB+xI6ysWMnj7z3OjvodJ5QRtIJcPe1qrp1+LZbP4kDzAVqjrczMmcn07OmDclE+HiqaKthUs4lzxp3D9OzpBC29PaG/xnqw+SiwzBjzOe/zp4FFxpg7j8t3O3A7QElJyYL9+/f3e1tv3XUHwRdfh2AyvuQkrzP1IT6LQCDonsv1+br2DHu8W1ZXXiwLfEKHEyaKg/HhdqACR8J15KcXMCFj4nHr+3p2pr11qse/9zh3a/Xci+12rjhMjLU1b7KgsIzVh1/nd3uexecP8Ll5X6Ap1sorla9xKFTN4VAtjl+I4XDJ5A+zuHAxCwoWMD17er8704ZQA0faj1CcUQxAc7iZtVVr2XB4A+flnUfQCnKg+QAHWg4QtsOsq1rXZ1mXTr6U7134PZL9yf2qQ2uklTtfuZNNNZvICmbx+fM+z6SMSRjc/5OAL8DKipXMGz+PG0pv6LWNrZFW1hxaw8T0iZw//vx+bX8wHGg+wMNbHub5vc93Hf2m+FP4wIQPsGTiEsoKysgKZuH3+dl+dDvL31vOhsMbmJE9g5KMEgyGVw++SpIviX8u+2eawk08vetp6kJ1TM2aypVTryQrmMWM7BlkBbPISsoiJznntE8Bq9FlrAebjwGXHxdsFhpj/rGvdc50gMBoZ4zpGubZXecpw+q2aqZlTRvSOm2p3cLayrX4xIff5+961bTX8Mttv2TZlGXcMvsWClILeGLHE9jGpq6jjrRAGhcWXcjUzKmsqVxDzInRFG7izcNvsv3odmxj8++L/52rpl1FWiDO40HjqCPWQcR2b+JL9acSsHofsGI7Ns+UP8NL+1+irqOO5nAzF5dcTHljOZtqNgGwtHgpnzz7k1ww8YKEOB2mEsdYDzZDdhpNJaYH336Qh7c8DIAlVlegzEvJoync1DUgopMlFrPzZrNwwkKWFi8dliOSRBN1omw/up381HyK0ouGuzoqQY31YOPHHSBwCVCJO0DgJmPM9r7W0WAz+hztOMq6qnVsrd3K1dOvZm7+XMC9/rCpZhPv1b3HxSUXk5ucS8AX0GHfSg3AmA42ACJyJfAA7tDnR40x3z1Zfg02SinVf2P+PhtjzAvAC8NdD6WUUjpTp1JKqSGgwUYppVTcabBRSikVdxpslFJKxZ0GG6WUUnGnwUYppVTcabBRSikVd6P2ps7+EpFa4HSfxJkHHI1jdYbKaGkHaFsS2Whqj7blRJONMfmnyqTBZgBEZOPp3DGb6EZLO0DbkshGU3u0LQOnp9GUUkrFnQYbpZRScafBZmAeGe4KDJLR0g7QtiSy0dQebcsA6TUbpZRScadHNkoppeJuTAQbEZkkIq+KyA4R2S4iX/bSc0VklYiUe+85XrqIyI9FZLeIbBGR+ceVlykilSLy4Em2ebe3/i4Rubxb+qMickREto3UdohIsohsEJF3vXr8x0hti5deISJbReQdEen3pEaJ0hYRmem1ofPVLCJfGant8dK/LCLbvHokfFtEZJy3vdbj84jId0XkoIi09rcdg90WEbG7/Z08d5Jt3uyVWy4iN59RW4wxo/4FFALzveUM3Fk8zwXuA+7y0u8CfuAtXwm8CAiwGHjzuPJ+BPwGeLCP7Z0LvAsEganAHsDyvlsKzAe2jdR2eOWle3kCwJvA4pHYFu+7CiBvNPx9dctjAYdx74EYke0BZgPbgFTcubf+ApQmeFvSgAuBLx6fxyuvEGgd7r+z06kDkAvs9d5zvOWcgbZlTBzZGGOqjTGbveUWYAdQBFwHPOZlewy43lu+DlhuXOuBbBEpBBCRBUAB8NJJNnkd8JQxJmyM2QfsBhZ6218D1I/kdnjlde7RBLxXvy7+JUpb+lPnEdaWS4A9xpjTvVE5EdtzDrDeGNNujIkBrwEfSeS2GGPajDGvA6FevltvjKnuT/3j1ZbTdDmwyhhTb4xpAFYBywbaljERbLoTkSnAPNy98YLOH5j3Pt7LVgQc7LbaIaBIRHzAD4F/OcVmel3/TOve3XC3Q0QsEXkHOIL7B/nmSG0LbqB8SUQ2icjtA20HJERbOn0CeLL/LehpmNuzDVjqnZpKxd1Tn5TgbRkSZ9IWbzlZRDaKyHoRuZ7eDWo/Nmqnhe6NiKQDzwBfMcY0i0ifWXtJM8A/AC8YYw6eZN2TrT8oEqEdxhgbOF9EsoEVIjLbGDOQ61DD3hbgb4wxVSIyHlglIju9I9B+SZC2ICJJwLXA3adT7z43MsztMcbsEJEf4O5Rt+Keaoudbv17bGDo2hJ3g9AWgBLvb34a8IqIbDXG7OnH+v02ZoKNiARwf0G/NsY86yXXiEihMabaO7w84qUfouceVDFQBVwAfFBE/gFIB5K8C2RvAvd4eT93kvVHXTuMMY0ishr38LpfwSZR2mKM6Xw/IiIrcE/h9CvYJEpbPFcAm40xNf1pQyK2xxjzC+AXXp2+5+VN2LYYY/o9wGQY2tL9b36v9/87T0TygIe9vN/01r/ouPVXD7jyZoAXRUfSCzdCLwceOC79fnpeWLvPW76KnhfWNvRS5mfp+yLhLHpe8NxLtwu4wBQGNkAgIdoB5APZXp4U4K/A1SO0LWlAhpcnDVgHLBuJben2/VPALaPh/wUY772XADvxLlAnaltOs70DHSAwKG3Bvdgf9JbzgHLg3F62lwvs8/LneMu5A23LgP4YR9oLd3SIAbYA73ivK4FxwMveD/vlzh+k98v5Ke6omK1AWX//4ICve+vvAq7olv4kUA1Ecfccbhtp7QDmAG979dgGfHOk/k6Aabgd3bvAduDrI7UtXnoqUAdkjZL/l78C73m/n0tGJKpXPgAAAfpJREFUSFsqcAcBteL+j5/rpd/nfXa8928NR1uAJd7nd733Pvsg4FbcARu76bYDM5C26BMElFJKxd2YG42mlFJq6GmwUUopFXcabJRSSsWdBhullFJxp8FGKaVU3GmwUWoYdHvq7nZxn579z94jUU62zhQRuWmo6qjUYNJgo9Tw6DDGnG+MmQVcinu/xD2nWGcKoMFGjUh6n41Sw0BEWo0x6d0+TwPewr2jezLwOO4TDQDuNMasE5H1uE9C3of7dN8fA/fiPlIkCPzUGPMwSiUgDTZKDYPjg42X1gCcDbQAjjEmJCKlwJPGmDIRuQj4v8aYq738t+M+zuU7IhIE1gIfM+5j+pVKKGPmQZxKjQCdT9kNAA+KyPmADZzVR/7LgDki8lHvcxZQinvko1RC0WCjVALwTqPZuE/svQeoAebiXlc9YSKuztWAfzTGrBySSip1BnSAgFLDTETygf/GfbijwT1CqTbGOMCncZ9ODe7ptYxuq64E7vAeO4+InCUiaSiVgPTIRqnhkeLNdBrAnRDsceC/vO8eAp4RkY8BrwJtXvoWICYi7wK/An6EO0Jts7gzaNVybEpgpRKKDhBQSikVd3oaTSmlVNxpsFFKKRV3GmyUUkrFnQYbpZRScafBRimlVNxpsFFKKRV3GmyUUkrFnQYbpZRScff/AVGzUa1WQmbzAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fbeca4b4128>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "attr = build_pnl_attribution()\n",
+    "\n",
+    "for column in attr.columns:\n",
+    "        plt.plot(attr[column].cumsum(), label=column)\n",
+    "plt.legend(loc='upper left')\n",
+    "plt.xlabel('Date')\n",
+    "plt.ylabel('PnL Attribution')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build portfolio characteristics (TODO)\n",
+    "Calculate the sum of long positions, short positions, net positions, gross market value, and amount of dollars traded.\n",
+    "\n",
+    "In the code below, in the function `build_portfolio_characteristics` calculate the sum of long positions, short positions, net positions, gross market value, and amount of dollars traded.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_portfolio_characteristics(): \n",
+    "    df = pd.DataFrame(index = my_dates)\n",
+    "    \n",
+    "    for dt in my_dates:\n",
+    "        date = dt.strftime('%Y%m%d')\n",
+    "  \n",
+    "        p = port[date]\n",
+    "        tradelist = trades[date]\n",
+    "        h = p['opt.portfolio']['h.opt']\n",
+    "        \n",
+    "        # TODO: Implement\n",
+    "        \n",
+    "        df.at[dt,\"long\"] = np.sum(h[h>0])\n",
+    "        df.at[dt,\"short\"] = np.sum(h[h<0])\n",
+    "        df.at[dt,\"net\"] = np.sum(h)\n",
+    "        df.at[dt,\"gmv\"] = np.sum(abs(h))\n",
+    "        df.at[dt,\"traded\"] = np.sum(abs(tradelist['h.opt'] - tradelist['h.opt.previous']))\n",
+    "        \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAERCAYAAACHA/vpAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzsnXd4lFXWwH93JjOZ9E5ITwi9hi5VEBFQBBSk2Naun3Vx3bUrrl12rVhhXXRFBQRRBCxIBykJHZJQ0gvpfTKZdr8/JsQEEkhIMhOS9/c8PE/mfe9772GSmXPPuacIKSUKCgoKCgqNQeVoARQUFBQULh8UpaGgoKCg0GgUpaGgoKCg0GgUpaGgoKCg0GgUpaGgoKCg0GgUpaGgoKCg0GjardIQQnwuhMgVQhxtxNh3hBAHq/+dEEIU20NGBQUFhcsN0V7zNIQQY4Fy4EspZd8mPPcIMFBKeVerCaegoKBwmdJuLQ0p5TagsPY1IUS0EOJnIUScEGK7EKJnPY/OA76xi5AKCgoKlxlOjhbAznwGPCClPCmEGA58BFx19qYQIgKIAjY5SD4FBQWFNk2HURpCCHdgJLBSCHH2svM5w+YC30kpLfaUTUFBQeFyocMoDWyuuGIpZcwFxswFHrKTPAoKCgqXHe32TONcpJSlQLIQ4iYAYWPA2ftCiB6AD/CHg0RUUFBQaPO0W6UhhPgGmwLoIYTIEELcDdwC3C2EOAQcA6bXemQe8K1sr+FkCgoKCi1Auw25VVBQUFBoedqtpaGgoKCg0PK0u4Nwf39/GRkZ6WgxFBQUFC4r4uLi8qWUARcb1+6URmRkJLGxsY4WQ0FBQeGyQgiR2phxintKQUFBQaHRKEpDQUFBQaHRKEpDQUFBQaHRtLszjfowmUxkZGRgMBgcLUqbQKfTERoaikajcbQoCgoKlxkdQmlkZGTg4eFBZGQktepOdUiklBQUFJCRkUFUVJSjxVFQULjM6BDuKYPBgJ+fX4dXGABCCPz8/BSrS0FB4ZLoEEoDUBRGLZT3QkFB4VLpMEpDQUFBoT1TvGYNRStWtPo6itKwE+7u7o4WQUFBoR1Tsvp7Sn74sdXXUZSGgoKCQjvAUlSIk69Pq6+jKA07I6Xk73//O3379qVfv34sX74cgC1btjBu3DhmzZpFz549ueWWWzhbgXj9+vX07NmT0aNH8+ijjzJ16lRH/hcUFBTaIObCItQ+vq2+TocIua3NS2uPcTyrtEXn7B3syYvX92nU2NWrV3Pw4EEOHTpEfn4+Q4cOZezYsQAcOHCAY8eOERwczKhRo9i5cydDhgzh/vvvZ9u2bURFRTFv3rwWlV1BQeHyR1qtWIqLUSuWRvtjx44dzJs3D7VaTWBgIFdeeSX79u0DYNiwYYSGhqJSqYiJiSElJYWEhAS6dOlSk1OhKA0FBYVzsZSUgMWCk69iabQ4jbUIWosLNb1ydnau+VmtVmM2my84XkFBQQHAUlQEYBf3lGJp2JmxY8eyfPlyLBYLeXl5bNu2jWHDhjU4vmfPniQlJZGSkgJQcwaioKCgcBZLYSGA4p5qj9xwww3079+fAQMGcNVVV/HWW2/RuXPnBse7uLjw0UcfMXnyZEaPHk1gYCBeXl52lFhBoWHMRUUUfv010mp1tCgdGnO10lDcU+2I8vJywJaNvXDhQhYuXFjn/rhx4xg3blzN60WLFtX8PH78eBISEpBS8tBDDzFkyBC7yKygcDFKVn9P7sKFaMMjcB89ytHidFgshdXuKTsoDYdaGkKIyUKIRCHEKSHEU/XcDxdCbBZCHBBCHBZCXOsIOR3N4sWLiYmJoU+fPpSUlHD//fc7WiQFBQCqTiQCUPLDDw6WpGNjKap2T/m0vnvKYZaGEEINfAhMBDKAfUKIH6WUx2sNew5YIaX8WAjRG1gPRNpdWAczf/585s+f72gxFBTOw5B4AoCy337DUl6B2t3NwRJ1TExZ2ai8vFBpta2+liMtjWHAKSllkpTSCHwLTD9njAQ8q3/2ArLsKJ+CgsIFkEYjVadP4zJkMNJgoOzXXx0tUodFf2A/Lv3722UtR55phADptV5nAMPPGbMA+FUI8QjgBlxd30RCiPuA+wDCw8NbXFAFBQUo37GTrH/8A48JE7CUlmJKTweTCZ85czDn5lGyZg3eN97gaDE7HOaiIoynTuM19Xq7rOdIS6O++tznJiXMA5ZKKUOBa4H/CSHOk1lK+ZmUcoiUckhAQEAriKqgoFC+ZQuWwkJKfvyRqsRE1N7eeM+bi/uVV+I1fRr6vXsxZWY6WswOR+WBAwC4Dhlsl/UcaWlkAGG1XodyvvvpbmAygJTyDyGEDvAHcu0ioYKCQg2G+HhcBg4k8puvz7vnNX0G+R8soviHHwh48EEHSNdx0cfGITQadP362WU9R1oa+4BuQogoIYQWmAucW9c3DZgAIIToBeiAPLtK2YpERkaSn59/yc8fPHiQ9evXt6BECg0hzWasVVWOFsNhSKuVqvh4dL161XtfGxqC67BhlPzwg1LFwM7o42LR9euHqlZFidbEYUpDSmkGHgZ+AeKxRUkdE0L8UwgxrXrY34B7hRCHgG+AO6TyFwmA2WxWlIYdSX/g/0gcEONoMRyGMTUVq16Prnf9SgPAa8YMTKlpNe4ShdbHqtdjOHYc18H2cU2Bg5P7pJTrsYXR1r72Qq2fjwPtImOooqKC2bNnk5GRgcVi4fnnnwfggw8+YO3atZhMJlauXEnPnj0pLCzkrrvuIikpCVdXVz777DP69+/PggULyMrKIiUlBX9/f3bs2EFlZSU7duzg6aefZs6cOQ7+X7ZfKnbsAGwfUpWrq4OlsT9VCQkAODdgaQB4TrqGM6+8Qsn3a3AdNMheonVoKg8fBrPZbucZ0BEzwjc8BWeOtOycnfvBlDcuOOTnn38mODiYdevWAVBSUsKTTz6Jv78/+/fv56OPPuJf//oXS5Ys4cUXX2TgwIGsWbOGTZs2cfvtt3Pw4EEA4uLi2LFjBy4uLixdupTY2Ng62eMKLc/ZEg0AVUnJuPR1bNFLR2CITwAnJ5y7dWtwjMrNDc+JEyndsIHAZ59BpdPZUcKOiT42DoTAZeBAu62p1J6yE/369WPjxo08+eSTbN++vaZ+1I033gjA4MGDa4oS7tixg9tuuw2Aq666ioKCAkpKSgCYNm0aLi4u9v8PdFCklJT+/HPN66pTJx0ojeMwJMTjHB190eQxrxtuwFpeTvHK7+wkWcdGHxeLc48eqD09Lz64heh4lsZFLILWonv37sTFxbF+/XqefvpprrnmGuDPcuhnS6FD/eXThbBFKLu5KRm39iTv7XcoWLwYp8BAzDk5VMbF4TV9es3vo6NQFZ+A28iRFx3nOnwYbiNHkPf++3jNmI7aw8MO0nVMpNlM5aHDeN9g39wYxdKoRkqJNJmQFkurzJ+VlYWrqyu33norTzzxBPv3729w7NixY1m2bBlgawPr7++PZz07CQ8PD8rKylpFXgXI//QzChYvxnv2bKI3rMe5Rw+KV35HxoMPYSkvp3z7dnL//TbWykpHi9qqmPPzMefl4dyr50XHCiHwu+8+rGVlyoF4K2POy0Pq9Tj36G7XdRWlUY00mTAkJto6YLUCR44cYdiwYcTExPDqq6/y3HPPNTh2wYIFxMbG0r9/f5566im++OKLeseNHz+e48ePExMTo/TZaGEKly0j75138Jw6lc4LXkTl6krwm2/g98D9lG/bRuq8eWTOf5yCxYvJnP+4o8VtVQwJtqKEul69GzXepV8/UKvRK0qjVTFXh+s7+ds3obnjuacaQGg0IATSaGyV+SdNmsSkSZPqXDt7hgEwZMgQtmzZAoCvry8/1FM1dMGCBXVe+/r61rSKVWg5Sn/5lZyXX8H9qqsIfv01hMq2t9L17ImuZ0/chg8n46/zsZaX4zp8OOVbtqCPjcW1nZasr0qIB0DXs0ejxqvc3HDu0Z3K6uANhdbBnFetNAL87bquYmlUI4RApdUiq1pHaShcPpSsWYMmJISQd962bSbOwW3ECKJWriDojdcJ+/gj1P7+5L33frtNajPEJ6AJDkbdhOZfrjEDqTx0uM4mTL//ALnvvtsaInZIzPm2PGcnf0VpOAyhdUYaO27Wr4IN05kzaLtGXzDDVhsejveMGahcXfG/7z70+/ZRsX27HaVsXSzFxeR/8glZTz9D+Y4dF8zPqA+3MaORej0V1ZawlJLUm2+m4JNPMec1r6iDtFopWLKEyiMtHDp/mXHWPaX287PruorSqIXQarEaje12x6jQOMzZ2WiCgho93nvObLRdupD17LM1H+TLneznnyfv3feo2LUL5y5d8Jkzu0nPu40YgdDpKN+0GSklRV8tq7lXeexYs2QzJieT+69/k3LTbKpOts0QaCkl5Tt2YiktbbU1LPn5qO3UQ6M2itKohXDWgpTI6tBXhY6HtbISS3Exms6NVxoqZ2dC3nkba2kZWf948rLvl1155Chlv20kYP58um3dQuQ3X+M+dmyT5lDpdLhfeSUlP/5IxkMPk/PqqzUJaIajzVMaZ335ACVttIxOxfbtpN9zDyfHjafq1CmKV39Pyq23UtqCPUfMefmo7XyeAYrSqIOo1tjSoLioOiqm7DMAaII6N+k5XY8eBD7zDBW7dlGweElriGY3DNUH357XXdeseTrN/yuyqoqK7dvp9OSTRCz7Cm3XaMq3bKmTZd9UartlyjdubJaMrUXh0qWArf9D0tTryX7mGSpj4yhduxYAq9GIpby8WWuY8/PtHjkFitKog8rFBYTAWtG8X6bC5Yv5TDYATk2wNM7iPfsm3K4cS+GXX7a0WHbFmJKC0GqbrDjPRRsZScSXXxC15nv87rwDoVLhfcONGI4dI/uFF+qMlVYraXffQ+LQYehjYy8479kDYJ85s6k6eQpTdnaz5GxprFVVVOz6A7/77yf0w0V4XjuFsP8swfPaa6mstrJy33iDk6PHkP/xx5dcPdmmNBRLw6EItRqViwvW8gpHi8KaNWs4fvz4xQfaEdOZM2S/9BLWCse/P62BITGRtLvuBkAT3HSlIYRA17MXluLiy/pczJiSijYiHKFWN3sul5gYnKOja1773X0X3nNmo9/1B9JkqrlelZhIxc6dWMvKLurCsRQUIDQa3MePB2hzob1nG1E5R3fBbcQIQt5+G/dRo9D164c5Oxtzfj7lW7chNBry3nufpGnTMKanX2TWukgpMefk4OSApnOK0jgHlbs7VkNlq2WGN5a2qDRKflxL8TffUljrULM9od/7Z86LU2DgJc2h9nAHiwV5GWeJG1NS0EZGttr8biNHYtXr60Q/VezaBYC2azT63Xsu+Lw5Lx+1vz+6nj0ROl2bSyI0ZWQAoAkNrXPdpV9fALKeehpTZiYBjzxC2H+WYMrMovi7VU1aw1JYiDQa0QQHt4zQTUBRGuegqi4GaDUYWnTelJQUevXqxb333kufPn245pprqKys5PTp00yePJnBgwczZswYEhIS2LVrFz/++CN///vfiYmJ4fTp0y0qy6Wij7O5DQo//xxLWRmpt/+F0l/q3xWacnIpWfuTPcVrNsb0NISLC91jYy85IkXlYSv3YrlMy7tIiwVjWlrrKo3hw8HJidyF/8KUm0vlkaMUr/wO525d8bp+GlUnTmAuKGjw+bNuGaHR4NKvH5UH2qaloQkJqXPdZcAAPKddX1Nm33XoENxHjcKlXz/0u3c3bY0sm0vuUizi5tLhMsLf3PsmCYUJDQ+QEqtej0hxRjg17u3p6duTJ4c9edFxJ0+e5JtvvmHx4sXMnj2bVatW8d///pdPPvmEbt26sWfPHh588EE2bdrEtGnTmDp1KrNmzWrsf61VkRYLlXH70fXvj+HwYbJfeAH93r3o9+7Fs/rgtHz7dnLefBP30WMoWfcTlrx8XIcOQdO5eb5xe2FKTUMbHo7a/dKLQqo9bQX6rKWlcInWiiMxpaeDyYQ2MqrV1lB7eRGy8C2ynnmW5JkzwSpBSjq/+CKaoM7kvYPt72rKlHqfN+fn14REuwwcSMHnn2OtrKzZ8DkaY0YGQqs9z3UkNBpC3noLz0mTqNi5C+futppRrlcMp+CzxVjKy1G7uzdqDVO2rTN2U0LDW4oOpzQuihCAgFYIm4yKiiImxtb97Wwp9F27dnHTTTfVjKlqIy1F9XFxlP2+iYqdO9H16YPP7Juwlpfje9utlPz0E2UbbOXCVa6umAsLyXntdUp/+gm1v39N5AhA5aHDl43SMKan4xzdpVlzXKqlYTUa7R5vXx+G6rwH5+4N981oCTynTEHbJZqMRx/BlJFJ1MoV6Hr3RprNqNzdqfhj9wWVhkt1P2yXgTFgNmM4ehTXoUNbVebGYsrIRBMcXFN+5lw8JkzAY8KEmtduV4yg4ONPqNi5C89J1zRqDfMZW5Sfk6I0Wp/GWARVp07ZGs60sInuXCvDWK1Wk5OTg7e3d02DpbaCPjaW1FtvQ2g0qLy9KF2/HqFWIXQ63MeNQxsRQcXWbYCtk92pceORUuL/4IO2gn6bNlO67ifKfttI5aFDjf4gOAL9/gNU/LELt2HDMGVk4D5+XLPmO2tpNCWpyxAfT/LMWYS8/Taekydd/IFWpOrECRCizuF1a6Hr0Z0uq1djysnFuYvNshFOTrgOHUrFnvrdNZbSUiz5+TXnBS7VmzD9gYNtQmlIKTEmnT7PNXUhXAcPQu3jQ9mvvzb6s2LKykbodKi9vS9V1EtGOdOoB6HTIQ2GVo+A8fT0JCoqipUrVwK2P7hDhw4Bji17XvTtclSennTbtZPAf/wDaTBQvPp7PK6ZiNrDA5f+/fG94w7cr7zSJrfRSJfVqwh49BFUWi2ekycR+sEHuMTEoN+9u00nS+Z/9BH5Hywi9bbbkUYj2rDwZs2nqu4fYS1rfNh20dffgNVK9jPPtPhZWlOpOnkKTViY3VraqtzcahTGWdyuGI4pNQ1TVtZ54w1HjwJ/Hio7+figjYpqM2XY9fv2UXXyFO5XjW/0M8LJCY+JEyn7/XdKflrXqGdM1VULHNHXRVEa9aBydUWazUg7fICXLVvGf/7zHwYMGECfPn1qqtvOnTuXhQsXMnDgQLsehJvz8ij79Ve8rr8etYcHuj62DycWC97VXQYBAp96kuC33kTXpw/hS/9bbxtQr+nTMBw/Tub8+Zcci97aGJOTcb/qKkI+eB//B/8Pj2ZaRWebDlnKGrY0pMlE5bFjSCmxVlZSumEDwtkZq15PlYODHqpOnLhgS1d74HrFFQBU7NkLgLmoiNx/v03F7j22ntiArm/fmvEuAwdSefBgmwhzLli8BLWvL94zZzbpOb/77kUbEUH2s89ibUSlbWPSaTThYZcqZrPocO6pxqD29MSUnY2lpKTFDtciIyM5Wr1LAnjiiSdqfv65VjvRs4waNcruIbeWsjJy//VvpNmM7+22drPayAhUbm6ovb1xHTaszni1lxdRqxpu6+kzbx7SZCbntddIv+dewj75GFUb6jxoNRgwZWXhdcMNeE6cCBMnNnvOGkuj9HwrUVos5P77bUp/+glzbi5uo0bhMmgg1vJyAp95hpzXXsOUnoFLH8f0IK9KTsaYlIT3jfbtBHcuzt26ofb1Rb97N943zCD/w48o+uorChYvBpUKbUREnfamLgNjKFm9GlNqaqtGfV0MQ3w8Fdu3E/DXvza5P7o2NJSARx4m4+FHMBw5guvgwQ2OtW0ukvCY6Bi3r0MtDSHEZCFEohDilBDiqQbGzBZCHBdCHBNCfG0XuZycULm7YykpaRO7F3uROf9xSn74Ae/ZN6GNiABAqFQEPD6fwGeebvBg70L43n4bwQvfQr9vH8Vr1rS0yM3CmJoGUqKNimyxOVXOzghn53otDcPx4xR+/jnm3Fw8pkym8tAh8j9YhCYiHK8bZgBgymhakldLUvztclCr8Zw2zWEygO1vznXYMCr27sVcWEjxihV4TZ9G8Ftv4nbFFXjPvqnOeNfqmlZ6B4feFixejMrNDZ+b513S865DhoAQ6PfuveA4Q0ICWK11rC174jBLQwihBj4EJgIZwD4hxI9SyuO1xnQDngZGSSmLhBCd7CWf2tMTU1kZ1spK1Hby7zoSU04uFTt34j1vLp2ff77OPd9bbmnW3J5Tp5Lz1lsYDh+B5k3VohiTkwFwjmrZ8FKVp0e9lkbFH7bD3chV3+HSpw+m3FwKPvkUt1EjUXt4oPbxwZie0aKyNAZrZSU5r79B8YoVeE6diqaT3T5mDeI6aBBlP/9M0TffII1GfO+4A12vXnjVo9C0XbqgcnfHcOQwVCtfe2NMTaX051/wu+vOOlZQU1B7e6Pr1YvCr5bh3LMnHuPrPxc5e66jc5BF6khLYxhwSkqZJKU0At8C088Zcy/woZSyCEBKmWsv4dSenrY6VK3U/tWeSCkxpqVhyq3/7as8dowzL/8TpMT3ttsuyaK4EEIIXPr2o7KWe85eWPX6eqvOms6cIe/dd8HJqcaqainUHp5YyusqDWtVFeWbN+PcvXuN+0nTqROdX3i+JvxSExZmy5OwI5biYpJvuoniFSvwu/cegl9/za7rN4TLQFtUVP4Hi9AEB+Pcs+H+5EKlwjk6mqrTSfYS7zzyP/oIodHgc/vtzZon6I3XcfLzI+P/HiTr2WfrrUxhSExE7eeHJtAxyt2RSiMEqP0Jyai+VpvuQHchxE4hxG4hxOT6JhJC3CeEiBVCxOY1s8FLzZxqNWp3j8vaRXVWbktREZbSUsy5uXX6PVgrK0m97XZSZs6iYsdO/O69B+cuzctTaAhd3z4YT58m+abZWOxU28uUm8vJceMp+uqr8+6Vrt+AMSWFkHfebvFzFrWHR81mw2owUPjl/zg98RoqDxzAc+rUBp/ThoY2uQZRcynbsgXjqdOEfPA+nf72t3o7FToCXS0l4THx6otGCWmjo6lKckwQQdXJk5T8uBafW29ptpWm696dyO9W4nP7bZSsWo2+nnbOptTWzdi/GI5UGvX9FZz77ewEdAPGAfOAJUKI8wKTpZSfSSmHSCmHBLRgAS+VlyfSbMaq17fYnPZASom5oICqhATMxcWY8/JRubjaXG5nzmAuLsZSVkbiwEHo9+2j09+foNu2rXT6299aTSa3ESMBMBw5QuF//9tq69Sm4JNPsJaWUrrh/EADw9EjOAUH2Q7AWxhtZCSGhESKV63m9MRryHntNTThYYQvXYrfvfc0+Jxzz56Y0tNteUJ2oio+HqHT4XHVVXZbszEIjQafW2/F8/rr8X/kkYuOd+4ShSUvv1WbHp2LlBIpJXnvf4DK1RW/exr+3TYFlVaL7222QBRT5vlhx8bUVLThzQsNbw6OVBoZQO2YsVDg3HcoA/hBSmmSUiYDidiUiF1Qe3jYXFSXUR0habViysqqKRdtyshAmoyo/XzRhIaicnXDlJFR83/ymjEDv7vvvmQ/bGNxHTSQ7rGxuE+YQNG337a69WZMT6doxUpUHh5UHjyIuaiozv3Ko8dw6duvVdZ2HToES2Eh2c8+iyYkhPClS4n43/9wu2L4BXfM3jfNQri6kv/pZ60iV30Yjsfj3KN7i1S0bWk6P/csIQvfalRpDW0XWzKiPUOWc155lZSZsyj77Td877wTJx+fFpv7bMFM05m6Zd+tej3mvDy0ER1TaewDugkhooQQWmAu8OM5Y9YA4wGEEP7Y3FV2c1zWlEq/jEqBmzIzsRQV4RQQgHP37qhcXBBOTqg9PREqFdqIcNS+vghnZ3rExRL02qt2k03t7obb8OFYCgqwtHJb1PxFixBqNcFvvQlSUvydLTTYlJ1N0bffYkpLa7XoE9chQ2p+Dluy+KLK4ixOPj74zJ1L6bp1GFNSWkW22kgpMSQkoGti/++2yNmyJ2f++TIWO5xDGk6coGjZMgzHj6P29sb3jr+06PwqrRa1nx/mMzl1rp91X7b0OVxTcJjSkFKagYeBX4B4YIWU8pgQ4p9CiLMhEr8ABUKI48Bm4O9SyobLX7YCKjc3rJWOL5XeGKwmE5aSEpz8/dEEBiLUarRRUTh37VpzuC3UarTBwTj5+aFyc2vxQ++L4dyjBwCGxBOttobhxIkaH7PH+PG4jxtH/ocfcfq6qZwafxVnFryEJiQEjyZk7TYFTUQEai8vvGbMaHQBurP43XkHQqOxi7VhyszEWlaGrlfvVl+rtdGGhhL43HNUxcfXew7QHKSUSKsVKSXFa9Zgysoi/4NFqNzcCJg/n+CFC5v8e24Mms6dMVXXmDpLVWKi7Z4D3VMOTe6TUq4H1p9z7YVaP0vg8ep/DkHl7g55ebbdezO7ZL388sssW7aMsLAw/P39GTx4MD/99BMDBw4kLi6OvLw8vvzyS15//XWOHDnCnDlzeOWVV3jyySeJiIjgwQcfBGDBggV4eHjwt3POICzV5aTVvr4114RKBXZWDBfi7I6wKjER99GjWnx+c1ERee+9j8rNrcbH3HnBi+S+tRBLWRneM2fiPnYM2ujoVivBIISg247tcAkuH6eAALxnz6bo66/xf+hBtOf0ZGhJDNXJo7peDUcmXU54XT+VnFdeseXftCAFS5ZQ/M23dHr6KbKfehqnoCDM2dn4P/QQ/vff16Jr1cYpqDOm1FTA5nYuXPoFee+8g1NQUKsFrDRKLoet7CDOvPYaVfEXKI1+DhKQVQakxWpz9dTzRePcqyedn3nmgvPExsayatUqDhw4gNlsZtCgQQyuzvrUarVs27aN9957j+nTpxMXF4evry/R0dHMnz+fuXPn8te//rVGaaxYseK8LHJzcTHm/HzU3t5tolpqQzj5+ODUqROGxMb/DhqLISGB5Bm2bGb/Rx+p8TFrOncm5O1/t/h6F6I5UUh+99xN0bJllKz5gYCHH2pBqepSlZAAanVNie7LHbWXF2ovL4zpLac0pMVC0VfLMOfkkPnIowCYs7NReXm1uEvqXDSdg9Dv2YvpzBmynnwK/Z49uE+YQNDL/3RoGfgOpzSaigDQaJHmSrBYoJE9Ns5lx44dTJ8+HZfqX/b1119fc29adcJSv3796NOnD0HV5Y67dOlCeno6AwcOJDc3l6ysLPLy8vDx8SG8lnlkwx46AAAgAElEQVRqqajAlJGBytXVIfX1m4rL4EFUbNve4uXAy379DQD38ePx+0vrfqBbE01gIM7RXTDU6mzXGhiOx+PcJarJJS/aMpqICExpLac0KnbswJzz57mC53XXUbpuHX533llTZ6y10AR1xlpWRupf/oI5L5+gV17Ga+ZMhxQprE2HUxoNWQRWi5XC7ArcvJ1xca/7RSalpOrkSUR1ItilRJpcKFrobMl0lUpVp3y6SqXCXF0hdtasWXz33XecOXOGuXPn1nneUlxiq8kTGWn3M4pLwXvmLMo2/Ez5xo14Xntti81bvmULLoMHE/bxRy02p6PQ9e1H+bZtSClb5UtCWq0Yjh2rKQ7YXtCGh7doxdviVatR+/hgqY6+6/zSArxmzMDtiuEttkZDeEyaRN77H2BKTSPk3XfwnFxvmprdafvfMHbEapHIenovCSFQ+/hg1esxJiXXm2F8MUaPHs3atWsxGAyUl5ezbl3jSiCfZe7cuXz77bd89913zJo1C2mxYC4qwpSbi7W0BLWHx2WhMADcRo5AExxcE9HUEliKizEcP477mDEtNqcj0fXtg6WgoKbZTnMx5eaSdP00ct97D2k0Ur5lK+a8PNzHXdki87cVtOHhmLKzG1Up9mKYCwsp27wZr2nTCF30AZ1f/idqd3fcx4y2SxKkNjSUzi++iNeNN+IxybF9VmrT4SyNhji7m2vIInDy90el1WJMT8eck9NkN9DQoUOZNm0aAwYMICIigiFDhuDl5dXo5/v06UNZWRkhISEEBQVhTE2t6Q4nnJxQt2CMeGsjVCq8Zs0k//0PMKanow1rfolnQ4LtjETXzzFF3Foal/4DACjfth3XYUObXR+rYMkSqk6epOrkScq3bEWajLbkxjb0ZdQS6Pr0BquVyv0Hmm0NlPzwI5hMeM+a6bBy8d433uDwqsPncnlsTe3BWQ9AA14kIYTtoM3XF3NBwSWVwnjiiSdITExkzZo1JCYmMnjwYLZs2cKQ6rj+cePG8dNPP9WMr30P4MiRI2zevBmrwYClrAyngAB0vXuj69mzVUL+WhPvG24AlYriVataZD5DdXBDe8g5ANuXnyY0lDMvvkjSlGuRzdg5S4uF4u9W4TntekI/XIQ5NxdTRiZB/3wZcYlndG0VtyuuQGg0lG/d2qx5pNVK8arv0A3o7/D+Im0NRWlUczFL4yyawECEVospM6PJuRv33XcfMTExDBo0iJkzZzJo0KAmyynNZoxpaQiVCic/v8vGJXUumqAg3MaMpmT1903q7Je9YAHZLy4473pVQjxOgYE41Qo3vpwRKlWd857mZDqbMjKQej1uw4fjMWEC0RvWE73up1YJeXY0Kjc3XIcOpWzT75fkRj5LwaefYjx1Gt9bb21B6doHl+c3TishhOBi1S2EWo02NBRpMmHKbpq/+euvv+bgwYMkJCTw9NNPX5KM5txcpNGEJiLyst8let9wI+bcXCqrW9zWh1Wv5/TkKaQ//DAVf/xB8bfLKV6+vI7CllJSefgIzj172ENsu+H/wP0EPGYL8zQcj7/kec4qHOeuXQFbBeem9LC+3PCaMR1TatolWxvWqiryP1uMxzXXXLDAZEdFURq1ETTonqqNytUVJ39/LMVFLXLg1lisJhPmoiLUPj6o3S7/Hh+63jZX0oVKZhiOHcOYkkL5lq2k3XlXzXVj0p/VZCq2bcOYnIzH1Ve3mqyOQOXqit/99yNcXTHEN0NpnLIpDW10dEuJ1qbxnDIFTXAwBZ8tvqQaZ/rdu5GVlbZaYA4Ob22LKEqjFkIIZGO0BtQU+LNHH/GzWIqKQUqc/P3stmZrogkKArUaY1rD5cArjx4DoMvaH/F/5GHcq3tPnLVOLMXF5Lz2OprgYLynn9uO5fJHqFToevSgYufOS67gajx9CqfOnS+7c69LRWg0+N51F5UHDlAZF9fk58s2bUa4up7X3ljBhqI0aiEaaWkAiOp8CqudlIbVZMJSVIjK1Q1VrVyOyxmh0aAJDsZUncFriI+n9LffKN+6tSYaynDkiK1sQlQUAQ89ROiiD1D7+FC8ajWW8goyHnkUU1YWwf9aiGjDmfDNwe+euzFmZJB6y63n1SK6GNbKSir27qsp39JR8J55I2pfX/I/a1oNL2k2U/bbb7iPHdtuPmctzeXtFG9pxMUPwmuGqtUIrRZpqGploWwffGNaGlgsOIU6vhVnS6INC6XqdBJ5iz4k/8MPqX2o5H3TTVTs3InrsKE114QQBD77LFlPPMHpKZOx5OUTvPAtXC8hqOBywWPCBMI/+5SMhx8hZe48Ipd/i6a6dPbFyP/0U8zZ2QS/+UYrS9m2ULm44Hv7beS9+56tku8FOv/VpmL3HiyFhXhe13JJp+0NxdKoRWMOwmujctZhrWqcpVFcXMxHHzU9U9mq19t6WUv4escOHnvyySY9HxkZSX4rlyFvDk7BwVQlJpK/aBGeU6cStXoVkSuW4zV9GsUrV+LUKQC/Bx6o84zX1Ovo9PcnsOTl4//gg3jVKsnSXnEbMYLwz/+D+cwZyn7/vVHPSKOR4hUr8Zh4NW4d0NXiM28eqFSU/bbxguOsRmONx6Doq69QeXriPnasPUS8LFEsjXNpgtIQOmdkWRnSar1o6OtZpXG26OBZLBYL6gbKkkgpbe4ItRptly6odv/ReOEuE872BQh8/jl8b7ml5rpL//4Evf56g++r39134zl5Mk7BwXaRsy2g698ftZdXowpuSikpXPY1lsJCvGfNsoN0bQ+1l5ethtcFetNLq5Xk6TMwJiej9vXFUlhIwOOPK66pC6AojVqIJringOpCbxJZVYW4SNXJp556itOnTxMTE4NGo8Hd3Z2goCAOHjzI8ePHmTFjBunp6RgMBh577DHuu+8+rBUVLF22jH8vXUpQaCjdu3evqU2Vl5fHAw88QFp1cbZ3332XUaNGUVBQwLx588jLy2PYsGFtvr+57y234DZ0KC4xMefdu5gibs9ho/UhhMC5V6+a856GMKakkP3SS+j/2I3rkCG4jWp/+RiNRdenL+XbtzdYw0u/LxZjcjJe06chtM5IiwXf25TcjAvR4ZTG9hUnyE8vr/ee2WQBCU7aRhYktFqxVlbiH3WKK2+7cOvQN954g6NHj3Lw4EG2bNnCddddx9GjR4mqLg/x+eef4+vrS2VlJUOHDuXGG2+k/NRpXvn4Y+IOHMDbx4fx48czcOBAAB577DHmz5/P6NGjSUtLY9KkScTHx/PSSy8xevRoXnjhBdatW8dnTTwItDcqV9d6FYZC/eh69qTom2+QZvN5eTpSSoqXLyfnjTcRTk4EvvA8PnPmtMlWrvZC168vJWvWkHTdVMI+/aROyRppsVD4xReoXF3pvGCBQ8uNX050OKXRoqiELbfD3PSufsOGDatRGADvv/8+33//PQDp6ekc37yZ7Kwsrhwzhk7Vh55z5szhxAlbx7uNGzdyvLqJDkBpaSllZWVs27aN1atXA3DdddfhcxnVpFK4OC4D+lO4dCkZjz6G3z33oOvbB5VWizk/n6x//IOKXX/gNmoUQa+/hqZT+wqauBTcR42ioFMnTGfOkHb3PUT/vAGhUmE1GMj82xOUb9pkc0cpCqPRdDilMWZ2ww1nSvIqMZss+AU3Pp696tSpS+qx4ebmVvPzli1b2LhxI9s3bEBbUcE1N9+MoaoKJ39/1A30OrBarfzxxx81/TlqoyQktV88Jk0i4G+Pk//xJ5Rv2oRz9+6Ef7GU/I8/Qb8vls4LFuA9Z7byN1CNNjKSbtu2UvLDD2Q9+RSGw4dxiYmhaNkyyn//ncDnnsP31lsuPtFlwDPfH0FfZebduQNbdR0leqoWtjONpj2jcnfHWl5+Xr6GVa/HUn1IDuDh4UFZdVXacykqKMBLo0FTWEji6dPsPXIETUgII6+6ii1btlBQUIDJZGLlypU1z1xzzTUsWrSo5vXBgwcBGDt2LMuWLQNgw4YNFFX3AVBoHwiVCv977yX65w0EvfIyxtRU0u64k7Lff8dtzBh85s5RFEY9uI8fDxoNhf/7iqqkZErW/oTLgAHtRmEA7E8totTQ+Dpul0qHszQuiKDJWsPJ3x9LURHGtDS04eGodDqkxYIxJcUWVVVdttzH15dRo0bRt29fXFxcCKwVZ391TAwfm80MnzOHHr17c8UVVyCEICgoiAULFjBixAiCgoIYNGgQluqaS++//z4PPfQQ/fv3x2w2M3bsWD755BNefPFF5s2bx6BBg7jyyivrdPhTaD9oOnXCe9YsnDoHkfHgg0ijEfcH/8/RYrVZ1J6eeF13HSVr1lBa3csm8CItmi8nLFZJUn4FY7sHtPpaoq1H1zSVIUOGyNjY2DrX4uPj6dWIktllhQYMFSYCwprWxtGi12NKS0NarWiCg5EGA+b8fJw6BSIrbRaHUKvRhIZiTEvDKaATmk62X67VaKTqxAmc/P3RdO7cpHWbQ2PfE4W2T/n2HRQuXUrwvxbW9EW329pVZjYl5HJdvyDUqrZt4UirFWNSEpWHDmFMTcPvvnvbTWmVtAI9Yxdu5s2Z/Zgz9NI2ikKIOCnlkIuNc6ilIYSYDLwHqIElUsp601aFELOAlcBQKWVsfWNaRB5oUp7GWdSurojoaEzp6ZgyMmzXvLxqFIOlogJjcjLG1FQArCXFcPZeYSEgUPu1j3pSCvbHfcxo3MeMdsja//olkaW7UjiWVcLTU9r2JkSoVDh37VpT7bc9cTrPFhEaHdD6StBhZxpCCDXwITAF6A3ME0L0rmecB/AosKf1hWpankZtVBoN2shItGFhaMPC0ISG1txTu7mhcndHqNU4+fpirarCUlGBtFqxFBWh9vRAZYf2kQoKzUFvNPPz0TPkl1eRnF9BXGoh645kA/Dp1iR2nW67lQfaO6fzyhlUpcZwuPXPMB1paQwDTkkpkwCEEN8C04Hj54x7GXgLeKI5izWU3FOb2o2YLuUwUahUqBto4aoNCwMpkVJiKSnBmJxsq11lsdjdymhvLkkF+/DR5tMs2nzqvOsf3jyIf/2ayBMrDrH+sTF4u7bPwpFtFSklvxw7Q4xFS0HSpVVCbgqOVBohQO2a2BlAnaa+QoiBQJiU8ichRINKQwhxH3AfUO/Br06no6CgAD8/vwsrg+pbUlZXvG1BziZYCcC5WzcsxcWYCwtRubigcrVfbwwpJQUFBegaCOVVqJ9TueXklBoY1dXf0aI4BItVsmp/Bu7OTsyf2B0fVw2+blo6e+noEehBmK8LMz/exd9WHGLJX4YoEVx2ZHdSIbHJRYyzuOIX2vruKUcqjfr+qmq2wEIIFfAOcMfFJpJSfgZ8BraD8HPvh4aGkpGRQV5e3gXnMRrMVFWYyS93RtjrUM9igYuUhWhpdDodobXcZwoX5+q3bV3gTrwyBa1Tx4tU35KYS3aJgUU3D2Rq//PrffUP9ebZa3uxYO1xFm9P4r6xHaPhU1vgg00nidI5Q4lsUo7ZpeJIpZEBhNV6HQpk1XrtAfQFtlTvWjoDPwohpjX1MFyj0dTJvm6Io9sy2fd1Ine8MQo3b6VgmQJkFlfy7m8nal7HphYyMrrjWRufbD1NiLcLk/o0HOH3l5GR7E0p5M2fExkc4cPgiPbRr70tE5dayK7TBTzdNxxzTh7+drA0HLll2gd0E0JECSG0wFzgx7M3pZQlUkp/KWWklDIS2A00WWE0BXX1DtJivvSG9ArtA4PJwqJNJ5nw7y2sjMuocVfevHgPH/x+ktwyA5nFlew6lY/V2r7PiE7llrEvpYg7R0WiUTf8lSGE4I2Z/QnxduHhrw9QXtX6iWYdnfd/P4Wvm5ZeOh1CgE/n1nd1O8zSkFKahRAPA79gC7n9XEp5TAjxTyBWSvnjhWdoWXJLDfxvXxohgNmkKI2OzOGMYh755gCpBXqm9O3Mk5N74u/hzIIfj7HzVD7//u0E7/1+Ep1GTXmVmeFRvnx2+xC8XNpnBNzG+FwAru0XdNGxnjoNb88ewKxP/mBlbDp3jrq4ha9waeSWGdh6Io/547tyauMZwnr5Nr7YajNwaJ6GlHI9sP6cay80MHZca8ri6aLhQEYxIWgUS6ODs/CXRCqqzPzv7mGM6fZnhu2/bhoAQHJ+BV/tTuVEThljuwXw1i8JXPvedt6fF9NuXDK5pQZ+PJRFfrmR9Uey6R3kSbB344r6DYn0ZXCED//ZkczsIWG4Odu+Zr7Zm8bG4zl8ettgnC5gsVwMq1WyZEcSgZ46pg0I7rCH7seybJFSXcohrczEoMkRdllXKSNSjU6jpmuQB5QZsCiWRofFapUcSi/muv5BNQpDSonVLFFrbF90Uf5uPD/1z5SiwZE+/PXbg8z5dDdPTenJ3aOjLusvssziSq7/YAeFFUY0aoG3q5aHxjftYPuJa3pw85LdPPbtASb0CmRPUgFrDtqOLDfG5zC578WtloaIP1PKa+ttwSNGs5WbhoRd5An7I6VkT3Ih0QHuBHjYzkfLq8y4atSoWijI5nhWKUJCQVw+nbt4EtzNu0XmvRiK0qhFvzAvTCcMZBfq6dyl/nwLhfZNckEFpQYzMWF/fgDjd2Wza/Upbn91JFrd+R+ZQeE+/PToaP6+8hCvrIvnVG45b8zsb0+xW5T1h7MprDCy9uHR9A3xrKMAS/MrcXZ1wtnV5oqrLDNyfGcWnSI8Cev1p5U1ItqPF6f25uV18WyMz8Xf3ZkbBoawKSGXl3+Kx83ZqY4VB7DxeA6/Hc/hkQldCfVp2Dd/IsdW+FOnUfHe7yeZMTDkgmctjuCHg1n8dbmtiOh1/YM4mVPGiZxyHpvQjfkTu1NqMHGmxEC3Tu6XvME4nl3KKK0LFXlVXDmnu902KorSqMXI3p3Y+nsOa/dlMnDIpe+E2islehM/HMrkpsFhuNjBd2pvTuWWcfXb2wCICfuzhlPasQKqKszkJJfW+WKsjadOwye3DuZvKw6xen8mr93Qr8V2lPZm28k8unZyp19o3Y3T9hUnOLwpA5VaEDXAn96jgjm1P5f4ndkg4KanhtApwrNm/B2jopjQK5Aqs5XoADeEEOw6nc8zq4/wyDcH+P3xK/Fzt+3C41ILuedLW4yL0WLlnTkNN+Y6kVOORi14d04MD3y1n1+Onak3DNhRmCxWXll7nCulM759fdh6uoB+IV4IBMv3pfPohG48vvwgG+NzCfWxRaQ9elU3vFybdiZ2PLOEqRUqfINdiOxnv4i+tqWeHUx0hO1DcvhEPhlFegdL0/Z44+d4XvjhGHf8dy8lehN3Ld3Hz0fP1Ds2p9TAb8dz7Cxh81i1PxOA0V396drpz9DFnGSb7/jH9w7yx/d/ZkTLc6KmhBDEhHtjtFjJL6+yg8Qtj8FkYW9yIWPPsQKyThZxeFMGPUcG0W9cKJmJxaz94BDxO7PpNqQTLu4afv3PMYrOVNR5LszXla61dtMjo/355LbBlBnMjFu4hWe+P8Kr645z53/3EeSl45bh4fxwMJPk/Lrz1ObEmTK6+LszsXdnwn1d+WJXSou/D80hLrWITsUWhpWouFHrwf7nJ/LFXcN4dEI3zpQaGP7aRjbG5zKpTyA9Aj1YuiuFV9efWwjjwhRVGCnJrUSnt9JvXKj98spopKUhhPACFgBjqi9tBf4ppSxpJbkcgs5Ng8pJ4G4VrIrL5LGruzlaJIeQV1bF06sPk1FUSYXRzMgu/swZFsbyfekMjfQhNrWIq9/ZSl5ZFbllBnxcNexNLmRvSiGH0ouJ9HfjcIbtT2PV/41o04fDaQV6DmcWEx3gzuaEXK7o4svbE3sRuy4ZF3ctTloV5UV/KoD9v6RxxYxodq46xanYXOY+Pwyd2587xJDqw+LM4ko6eTYu677UYOLjLaeZOSiErp2aVmG5pdmckEuV2cqEXnW7/iUdyEftpGLsnO5onNWMmBFN8uF80hMKGX59F4pz9Wz45AjfvRHL1Xf1Iap/wzvfnp09+e6BEfzvj1RW78/AYLJyXf8gHhrXFX8PLd/FZfDR5lMsrA48OJeEM2UMivBBrRLcPiKCV9bFczSzhL4hbcOlvCUxj94mmyVelPPn5nN8N38e8vDlV4ueKp0Tr97QD393Z15dd5z/7EjmrtFR9Ozs2dC0dTiQXkSw2bbnD+lun7OMszTW0vgcKAVmV/8rBf7bWkI5CiEE7t7ORLnpWL4vjUpj09u4Xu5IKXlp7TG2ncgn3NeVTh46lsemc9+XcYT4uLDkL0P58OZBFOuNOKkERzNLmfPZbt7eeIK8siqm9A1CCIGvm63+0Etrj9f4oNsiT646zMNfH2DKe9tJyypjrF7D5q8SiF2XwvblJ9j8P9uBa6+Rf7orf11yjEMb06koriLpYN0qA8G1lEZDmC1WMosra2qAvfpTPB9vOc217+9wuIWy9nAW/u7OXNHlz3poUkqSj+QT0sMHjbPty1CtUdF1cCfG39ITV08twV29uenpIXh1cmX9R4drrLOGGBjuw9tzYtj77NVs/8d4Prx5EL2DPenkoWPesHC+P5BJeqG+Zv30Qj1VZguH0ovJLK5kaKTNfXjTkDBcNOo2Y21kFOlZE5dBZLXSyD5dgsViC6xJP5SPa3ol/wjtzN5nrsa/2jV31+BwRpq1vPj9UZKqq9VejLjUIkKtKpxdnfAOtF8ZImj8mUa0lHJmrdcvCSEOtoZAjsbN25lIg5qsknze+/0kT03p6WiR7Map3DIW/pLIL8dyeHxidx6d0I3cMgMjX99EqcHE0jtH4uWiYXLfzqx7dAxSwusb4pnQK5Bp/YMpTy/n9y/iuX1KJH3GhPDDwUyeWX2ESe9uY2r/YF6Z3rfJftvWpLDCyJ7kAuYNC2dktB/p27ORR0vIBwZPiWDAVWHoy4xIq8Q/1IOB14Tz9YI9nIrLpd/4UNKOFXBsWyZdYgJqrI0Qn2qlUXS+0iipNDH3s93klRnILzfSI9CDYVG+LI9N54ouvuxOKmTHyXxmDAyx59tQw+6kAn49lsNtIyIw6c3E788lvLcvFSVGSvMqGTjxwn0aPP1cmPZYDP/523bSEwoJjLr4rtlTp8FTV/dv4oEro/l6Txofbz3NK9P78uyaI3yzNx2NWuCh0+CmVTM+yIc17+zHUG5mTrdAvj6UxVNTetackTiC7JJKbl68B12lBYGKbkMDObkvh91rkgjv48vJWFu+i9FgqTkTzE0tZe07BxhhUPPDyRKmL9rJ9ifHX7Doo5SSbYl5jJFOBEV72T1Sr7FKo1IIMVpKuQNACDEKaHgrdRnj5u1MRaqROUPCWLw9ian9g9qM2dsctp7Iw8dVQ//Q+k3ZEr2JW5fspbzKzBPXdOeh8V0pztGTuDWD56JCiLoyuM770D3Q5kZZeucwpJQc+j2dXatPI62SE3tz6DMmhOkxIYzpFsCS7Ul8svU0oT4uPDm5bShhi1XywaaTWCXcMjyc7n5uLF+Zwtn9cZeYAFw8tLh4/Pnh9Q50JaSHN/5hHoya2ZWEPzzY/FUCX73wB9Iiiezvz5jZ3fHQOZ1naeiNZv79ayLx2aWM7urPiGg/Nsbn8L/dqcSEebP0zmEMf+13dp6yr9KQUrIyNoMVsenEphYR4efK/IndOfRrOrHrUwDQujihc9PQY/jFm4Tp3DR4B7qSmVhETnIpaifB5Pv6NUmmAHctd/j7sn97Fos8dXyzN51bhofj6aLhSEYJV3bx47cPDwOgUqsI2l9JgBOsiM3g/8Y5puZVbqmBmxfvobDCyDtjunFiTQqDJoUjBBz8LY2Dv6XVjM3PKKOy3Mgf358mflc2zq62r+G7ugfzVEoGz645ys3DwhkY7o2r9vyv6P1pxeSkleFm1BHR1/59eBqrNP4P+KL6bEMAhTSikODliJu3MxWH8nl6ymB+T8jlqdWHWfPgqGYlIzmCiiozRzJLGBTuw8q4dJ79/igA1/QO5IlJPbBYJaWVJo5nl7IpIZd9KYWYLJLvHxxJd2831n98hJTDf/ZHCB8WTF5aGT8vPlqTx9J7dDDlhQb0pUZSjxbQJSYAVy8tx3dkkbg7m8Q9Z5jyQH9u7xFE5Y5cvvk9ieziSl65oR/uzq0fuLcpIYcNR85w6xURDAirqyyX70vnvztTmB0ewOmVSWw/WYzVIhlwdRhWk7Xe7o1CCGbMH1TzutfIIALC3dm7Nhkp4VRsLunxhQz0cialQM+epAIOZRSz/WQ+e5ILbTkFg0NrfPUPje9KeqEeXzctOo2aEV382HYyj/Iqs13eH4AfD2Xxj1WH6drJnScn9+SmIaF46jRkJBThF+JO92GBJB3Mo+eIoBrX1MUIjPQkcc+fARIleXq8AhrnQslLL2PTl/F4pVcwXDjx9m8nGBzhw8vT+9ZEo2UmFrGmLI3rHuyPX6g7P753kDm5FnbvyXSI0jhTYuDmxbvJKTXwv7uHYT5cjBC2TcbVd/Zm0KQIqvQmjJUWziSXELchlW9e2kNVhZmYCWEMuS6KX5ccpTzXwCM6b0p2FvJUXA55rrDu0THnNVb6Zm8agyy289euQwIbkKr1aNRfppTyIDBACOFZ/br1i7Y7CHdvZywmKxqz5J/T+/Dgsv18szeN20ZEOlq0RpFRpGfJ9mRWxWVQVmXGy0VDSaWJcT0CGBTuw+JtSUx6dxtOKoHJYvOpdw90Z+7QcKb2D6KHrxvrPjxMbmoZQ6+LpNeoYH5adIgdK08SPbATZQUGelzRmexTxexbl1xTl/iKGV0YNCmCjPgijm7NZOPSeAC+ezOWwqwK/IGhWifWHMjCaLHy0S2DW/V92JKYyz1fxGKVcCijmHWPjqmJ5ZfSVua7j78bPZOqKNaY6H9VGFH9/ZucIOUf6sG1/2fLycjPKGfjf48xLFvP22V5bDthO+/o1smd26+IYFyPTgwIcOfnT48w4sZovAJcCfP988v09pER/PafHB5atp8lfxlil9yD7+IyCPVx4de/jtxCFtAAACAASURBVK35UjYazOSmlBJzTTiDJkUwaFLTMo0Dwj1I3HOGfleGcGRbJrvXJDF2bndUakHmiWK0OjX+YR51AggAis5U8N2bsTi7aojs50fKkQLuGxHJXeOi64QvF2RV1Kzj5u3MjU8M4vPnduGWYWDd4Wyu7dfZLi6b5fvSSCnQs+FINvnlRr68axiDI3z5+ZcsPPxdcNLYlKxfyJ9f+h7+OuI2pFJZZmLiXb3pPsxmvYX08OGP1afRAW4aJ+ZWqIg3mvkjMa+O0jBbrGw5nsPtJg3Rtdyi9uSCSkMIcauU8ishxOPnXAdASvl2K8rmEEJ62A7Ykg7kMeXKEAaGe7NkRzI3D49o8z2Q88qqmPnxLgorjFzbL4gYrY6szdlsCFTx75sG4OfuzG1XRPDJ1tOkF+npF+JNlwA3JvXpzMl9OWTsyGVN6ikKsyqYeFcfug62RdCMmtmVtR8c4tDmdALC3Jlwey8Obkxj53encNKquGvhmJpdaHAPb3qPDiYjsQg3Ly15qWUMuS6SwswKOJhHjNGJtF2FJF1TTpf/b++8w6Ms8gf+mW3Jbja9ERISCL230EVRVBTsouipZ/esp6fenZ4/z9NrtlPP3hU9y3kiihUBuzTpJHRIQjrpbTfJlvn9MZuQIIRNSLJJnM/z7LO77877vjPvvu98Z75tOmlpyr3FNdzyzkaG9QnjNyekcuu7m5j6jxXYg01U17mprnPh8kh+HxNLnaOWC/80qUOyg8Yk2Zk0bwBfvJjOxFAbCQMj+POZI5oMngCblu9n78ZiSvNrWfB/kzCaDGxankPOtlKOv3gofztnFHd/sJX/W5zOg+eP7tTOr7Cyjh/2lHDLiYNadMqZm1USxiPFpByNkTP7EtHHRvIIlQtp4/L9ZKWXYg0xU11WB4ApyMi0c1IZPSuJeoebXWsLWf3RPgxCsOCeSRTurSRraynXjk8mNrylF1pZfg1BNhO2cKU6tIZaiE6yE51VwU1vb+Dta6d0eCZit8eLQQiWbM5namo0izbk8sjSnQDYg0wsvGoyE1Miyc4oZf+20iNeu+i+di65fyrFOdVNzxfAqJmJrPpgLwC/um8KO1YVwKdZ5PxQCMep/F2VThfvrt1PdKUXo1sybHpgYsmONtMI8b0H1g+wC4ntF0p0op307/IYOCGOa45L5aa3N3DjW+t56uIJ3XItBSklX+0o4l+f76TC4eLDm2Ywsm84y17NwOGCl+eMajIQRoZYuHvucFwNHrxuL0E2MzvXFLL89W1Ns4Y5145qcUP3GxFF0rBIcneUk+AbiTcK176DI1qoLYxGAydequwWHrcXj9uLJdhE3s5y9m0uxhYRRHJ5Pe9/uZc/XHJ4l8r2cqC6jj++v4WvdxYTHWLhxV9PJFwaeOnSiXyeUYhHSkKDTdiDzETUefF8WciYE/t1aDrpvj73xz9M6M+kuT9P1pe5Wan8KoocfPjYRsadnMzKRSr2Y/WH+7j4ulHklTt5+us9jE+O4KLJrRufj4UPN+UhJZw34eDaKm6Xh/WfZxGdGEJiO9NSmCxGUkYqXfv08wcxbHoC6z7LImd7GXOuHUWQzcTmFTl8/9/dFOfUUFHooHCfctEee1I/QsKDCItVDgWVxU5ik1t2P6V5tUQntoykTkoJpyy7GiSs2lvaoULjL0syWLatiAkpkXy8OR97kImaejfnjOvLBWn9iAsNYlCcnQ1fZrN68V6i+tqZMf/I65BHxNt+5vFksZq48E+TqCpxEhZjZfKZqXy6JpeYLCdffpvNO/uK+GFPCS6P5GKTjeBQE0nDAuPK3qrQkFK+4Hu/v2uq0z2YNK8/X76awTv3r+G4Cwfx+zlDeGTpLv715U5+d8oQgs3dIxq6pt5NvcvD22v2s+yTvcxzWhh27RgG2K04axrYn1EGQMGOckJCLGSnl1KcU01DnZvKYif2iCAmnTGAFa9vI3FIBLHJYTTUuRk4oWVglxCC6ecN4oNH1jdFnsYk2kkcGsmwaUce7RhNhqZ084lDI7n+yVl43F5euOM7ctYcIH1Wx/rWP7x4GzHrK4m2Cf516nDWvrKdgj2VJI+M4pHrxzTljnLVe1j8rw3UhlmYfGbHZmG12i1EJ4aQt7OCSXNb/lZdVkfBngrS5vUnJsnO8te3s/SldCzBRobP6MvmFTkU51Rzx6lD+HZXMa/8kMmCSf06ZLbhbPDw/Ld7GZMUzqyhcdTUu3l37X4mpkTSP0aNDaWULH0pg/JCB3NvHNNhAWNRCSGcevXIFtuShkay9pPMJmP7rEuGkjQsCnukGtyExyihUVXS0qHA1eChNK+GoVNbGuUjE2xIt2RKfBhrMss6pN6g1Hev+9x58yqcDI6zs/tADRdN6sffzx3dpH3Y8nUuqz7Yy6CJcZz06+F+23+aE5sc2kJA2qfEUPF5Phve3cOOJLhien/mjk4g/YXtxCaHBizjwNHUU0+29ruU8rcdW53uwcAJcSzoE8JXb25n+WvbOfGyYewe15cXvtvHx5vzeeKi8UweELiANSkldy3ayn/XHVwt9xZCAC87XtrJDnY2bbdYTexcW8S2HwswmQ1EJ9lpcLpx1XkoL3Tw5csZJAwKZ96NY1u90WOTQ7n2ieMx+PTswiA453fj21Rvo9mA0Wxg1IlJGFbk8uRzG3j83plNWVDbgrOmgeAQc1OHmlPmoHR9CWluE7daQti+cDcWm4mRxyeS8V0eG77MJm1uf3avK2LVB3upKa9nzrWjsFg73uCcPDKazctz2LvhALHJoRjNBupr3Wz5Wv1fw6cnEBZtJSLOxrJXt5E6Loaxs/uxY1UBqz/cxxk3j+GyqSn8YdEW/vHZdmJDg455JbzfvruxKUI/McKKECpq/76zDnbmOdvKyNpSwvTzBrUanNcRCINgylmpxCaHUrC3khEz+rYQUhariWC7mcpiJztWFZA6PhZLsIkdKwtw1XsYPKmlATgyQQm+CREhvLKviEqn65hT1W8vqOKexVuZmhrF+ORICiqcPHbhOIpr6okLDWJ/RhnF+6uISQpl1Yd7SR4ZxanXjOwwleLFx/Xnvs3FTMj18PLckYwcH4+jqoGVpXWMOiFwK28e7YlZ3yW16IZE9Q3hvN9P5L2/r2XbD/k8eucEzhzblwc+2cZFL67i1tlDuPmkQV1u59hdVM09H6ZTsbOCm61hhIYFYQ4y4txxMDh/8pkDsFhNGE0GEodEsGZJJvaoIKadPRCj2YCrwYOjsoH3H1qHyWxg3k2tC4xGDB1kmJ11/mDy91czZncFD728gQdumtxq+bKaeiqyq8nZUkp6TgXEBMHaMk64eEjTw/PR91mMqTcSHGamuqSOoVP6MOOCQVjtFuqqG9iwNJvs9FKKMquITQ7l1KtHkjCocyJp+4+OYeOX+/nixfSf/TZwQhxh0WoUHZ1o56J7D7Z94un9WbloD1//ZwdnLhjM+xtyeen7TABOGhbX7mjxrJJalm0r4rcnDWJ4Qhhvr92Po8HDYxeOY2JSBGs/ySR3exlFWVXYo4IYc1LXdUip42JJHRd72N+iEkLY/VMR237Ip7qsjrj+Yaz6cC99UsNJGNhyhhqTaMccbCSx0I3J5eWxL3dy/9mj2l2v9dll3PruJsKtZp66eAKxoUGU5NZQU1aHFX7mXYiAWZcM61AbVFKkjef/cByv/v4HNn2YSdbKQupq1cJWfVL9ixzvDI6mnlrY/LsQIlRtlv6FLfZwDAbB0CkJrPxgDzUldcweHs+U1Gju/TCdx5fvYtW+EhZeNZkgU9eoq3LKHJz33EpsRgO/9toIrgdLtZuqTPV3nHLVCEKjgn/WGZ52XcuHx2wxEh5r5Vd/mYIlyNSktukqhEGw4JZxPPeXlURtrebHTQXMGHd4NVduYTUL/7qGCI8BtwCTBPYp75l9m0sYdUISu7MrqFhegN0ouPCuSSqyP/Kg8XnGBYNx1rioKnVy4qXDGDY9oVOn9n1Sw7BYTQgDpJ3eH5PFqDLDWk2tZk8ed3I/Gpxu1n2WhavewzNnj+G7vHLu+N9mPtyYz51zhrarPsu3qxnGBWn96Bdl43TfYkpVJU42Lt/PT59kEj8gjLGz+zF8ekKTSjHQpIyKJn93BQCbV+TQUOchOjGEOdf+fDRvsZo44aIhLH99OzeYbTz3YzYj+oaxYFLbbUI5ZQ4ufXktUSEWnr90AntX5PLZmkJqKxsQKNOf0Wxg+nmDGDghlhULtzPiuL6ERvmXNqYtmC1G0k5PYc/6A9RU1COEIGV0dIvEkF2NaExl0GohIUYBbwJRqDiNYuDXUsqMzq1e20lLS5Pr1nXcirC1lfW8cfdKRp+YxHEXHMxF9ebqbCU8Fozl3PGdPzLbmlvJA0vSMe+r5fzkWAq3lXP2beNIGhaFx+WlvKiWmKSe5a9QWFDD+/evoWFoGLfdmsYXGYUUVdUREmQiITyY4wbF8PyT6/Fsr8QxLoJ9wV4seXUUFTsYE2oj3iFxj42genUxZgnjLh7MrOM7z3DcFpw1DViCTe3qgDcszWbVYuVJc8YtY7l3zV6+21XM1NQoLpqUzNnj/F94qMLRwIUvrEIgWPq745u2H8iuYtEj6/G6JXEpoVxw96Q217OzKS+s5e2/rMFkMeBu8JIyOppTrx552PT0jeTuLOejxzeS3c/C+zWVPHfpxFbXNT8UKSWXvbKWjfvLWXb7CRSsVhHd1jALA8bGEGwzIQyCkTMTO0VIBBIhxHopZdrRyvmr0H0RuF1K+bXv4LOAl4Dp7a5hDyEkPIiBE+PY9kM+Mf3sDJuqRmmnJUaxLMjGmyuzOlVobM6p4N6P0tmSW0ma28SMGjOF28oZMiW+yYPJaDb0OIEB0CfBTqXdiGd3JTMf+pq8ypZGz76hwVyQC2XhRv56/cG4jidX7Gb5p3uZ47DAyhJkiJHZV45g9Ki4Q08RMKz2I6eBOBoT5qTQJzWcxf/awL4NB7gqLJIpVjcflDu57b+bcHsl8yce/Z6rd3u48vWfyCp18NwlB4MSPW4vX76SgTXEjNcrmXh6/3bXtTOJiLcx/pRkUkZFI6Wk75DIo84Qk4ZG0ic1jKAiB+fa7Nz35iYSbp56xEwIoFxZi6vriQ6x8MHGPH7YU8JfzxlF2ZYyVn+4j8GT4jnlyhFdmkm2O+Ov0AhpFBgAUspvhBAhre3Qm5h8xgDKC2tZ8fp2ygsc5Gwvo3h/NVOAt2urySlztAjS6ig2bS/m3ec2M9gsOM0UhqxxEZ1kZ9zJ/Rg8Mb5Hrw7XSPzIKOrXlDAuwsYdc4Ywa2gctfVuVu0rZdPqfCw5tcw8tWVw2W9nD2ZSfBg/vL6DAWmxnHfh8B67dsWR6Ds4goETYtm5tkilYPdIbhoUzrNRgvfX5xxRaDga3CzbVsTy7Qf4blcxlU4Xz140npOGHhSoG7/MpvKAk3k3jSFlVHS3vY+EEEw//8iuq0fi+IuHsmrxXhq2l5EqLSx8bzv33Zj2sxxXoGJV5j75PWW1DU3bzusThe37Er7dW0nyyGhmXzFcC4xm+KueWgxsQKmoAC4F0qSU53Ri3dpFR6unGnE1eHj3gTVUldQR08/O0Cl9WLV4L2tNLmbMH8Q1M1OP6fget5d9m4oJCrOww+lkxe4SGn48wCCnAbPVSEJqBAmDwhl5XN8W+ZB6OpXFTv5z7ypmzB+EMAgclQ2Ex1mJSbKzYWk2uTvKufLh47qNnr0r2b2uiC9fVhrgtLn9Wf95Ft7YIB6vryAtNYqx/SKYNSSW6YNiyK9wcv/HGXy14wAujyTGHsSJQ2OZO6oPBz7IxmgycNat41i7JJPNX+UwcEIsc64d1W0FRkfgqGrglT+vZLfHxZIQlU+uMWDS41VZAZ75eg8Hquq578wROBo8mKTE9VEeZouRUSckMuakpKbI7t5OR6unrgLuBz7wff8OuLKddeuRmC1Gzr1jIvUOV1NagLxdFdRuK2Hhyiympka3iDkorKyjqs5F/+iQFgGBJbk1hMdZMTdb+a7S6eK55zcQuvPgwjNRBondayBleh/O+PXB9ah7G+GxViL72Fi5aA9SQpOl0cfE01J+kQIDYNDEOIQQ1FbUM3Z2P8JirHz1xnZuGNuHbxucvL4yixe/28cpI+KpcDSQkV/F5dP6c/KIeCb3j8JgEGxctp9tOcpR4o0/raTe4WbsSf2Yfv7AXi0wAGxhFgaOiUFuKOb8cbH8d10OcWFBTOofxadbCvh4bQ5Twu3cOqQfQ5wGhk9PYvvKfL6tcXHa7aNIHBJ59JP8AjlanMabUsrLUEbvDo/JEEKcBvwbMAIvSykfPOT324FrADfK+H6VlDK7o+vhL/bIoBZeOQMnxJK1pQRrjYcznvqBmYNjuHhyMrnlDp5YuovIeqg1SEJjgpnRJ4JxJZLSXZWEDwzjkjsnIoSgotTJ7W9tZNguJ4XBAuPQUEaGWBnYAJHxNiac2ra8Pz2RYdMSWLV4L8EhZi772zTqal1kbi7BUdXA5LOObQbXkxFCtIjMHzatD+u/yKJfg4E7bz2OereHV37I5OkVexD1Hm5LjCdsYzX9RyRiMAi8Hi+bV+SQNCyS0ScksfaTfUw9ZyCjjg9M6vVAMGRsHJlrD3D9oATyq+p46quDKy/eao/EklNHQU4RBT8Wsf6LbFwNHhIGhrc5B9kviVbVU0KIbcDpwBJgFmoc2ISUst2hl0III7ALOAXIBX4CLpZSbmtW5kRgjZTSIYS4AZglpVzQ2nE7Sz11OOpqXbz2hx8Ydnwi2+MNvP5jFgeq60HC9a4QQh0qG2y91YC3zoNRQrbZy2CXkegh4cxeMIS3Hl6Pud4LBsH8P0wkvn/gXOkCSf7uCoJsphbJ3TQ/Z9XivWxctp8rH5qBNdRCXY2Lz1/LID/j4KNosZoYPiOB8oJa9meUMfeG0QwYe/hYiN6Ox+Xlg0fXU1HkYOK8/jiNYB5gp77GTfrz24hNDuWky4ZTW1XP2iX7KN5fw/y7JvZIx5JjxV/11NGExm9RadFTgTxaCg0ppWz3MFAIMQ34i5Ryju/73b6D/vMI5ccDT0spZ7R23K4UGgCfPruFvF3lnP/7idjjraTnVeEtcLD29Z0qyC7YRHZGKdkHatjT38KZ05N55eUtTHYYsfgupwwxcsYVI7t0cXhNz6Qsv5Z3HljDqBMS6Ts4gpWL9uCoaiB5ZDQ15XWcfMUIPn12C46qBkKjguk7KJwTLhnW6xwF2kJVqZN37l+Du0EN4uIHhBEea2XX2iIuundy00BFSomr3tOqS29vpkOERrODPSelvKFDanbwmPOB06SU1/i+XwZMkVLefITyTwOFUsq/Hea364DrAJKTkydmZ3edBqumvI73H1yH1ys5+7bxuOo9fPHCVqSEX/99+mED5wor6/hxayH7vsoj2Gzkpj9OxmD4ZertNW3nk6c3k51eCiib0KnXjGwR7CW9EgS93mbRFgozKyncW0mQzcSqD/fhrGpg1PGJnPCr9gVM9kY6Wmg02jZa3dbGCl4AzDlEaEyWUt5ymLKXAjcDJ0gpW11EuatnGqCCkD56YhNul4fgEDMel5fTrx8d0KhNTe+lsthB5uYS4geEE5ts/8V493QUDU5306JhXZ0NoTvjr9Dw94q1SFEphDABx7qKTi7Qr9n3JCD/0EJCiJOBe4CzjiYwAkVknxDOvWMClmATlQecTD4zVQsMTacRHmtj3MnJJAwM1wKjHVisJgZPitcCo50czXvqbuBPgFUI0bhanwAaUFHix8JPwGAhxACUveQi4FeHnH888AJKjXXgGM/XqYTHWjnvzglkbi5h6JSuX4JRo9FouoJWRa3PKB0OvCGlDPO9QqWU0VLKu4/lxFJKN0rltBTYDrwnpcwQQjwghDjLV+wRwA78TwixSQix5FjO2dnYI4MZPSupw7LBajQaTXfjqG4CUkqvEKJjl1g7eOzPgM8O2fbnZp9P7ozzajQajaZ9+DskXi2E6H5pMDUajUbTpfjrkHwi8BshRDZQiy/Zg5RyTKfVTKPRaDTdDn+FxumdWguNRqPR9Aj8Uk/58j1FAGf6XhGBzAGl0Wg0msDgl9AQQtwKvAXE+V7/EUL8LAhPo9FoNL0bf9VTV6NSfNQCCCEeAlYBT3VWxTQajUbT/fDXe0oAnmbfPRyS8Vaj0Wg0vR9/ZxqvAWt8K/gBnAO80jlV0mg0Gk13xS+hIaV8TAjxDXAcaoZxpZRyY2dWTKPRaDTdj6PlngoGrgcGAVuBZ33pPzQajUbzC+RoNo2FQBpKYJwOPNrpNdJoNBpNt+Vo6qkRUsrRAEKIV4C1nV8ljUaj0XRXjjbTcDV+0GopjUaj0RxtpjH2kHU0GtfVaMw9pVca0mg0ml8QrQoNKaVeFkyj0Wg0TejVgjQajUbjN1poaDQajcZvtNDQaDQajd9ooaHRaDQav9FCQ6PRaDR+o4WGRqM5KmsL1lLVUHX0gppej79ZbjsFIcRpwL8BI/CylPLBQ34PAt4AJgKlwAIpZVZX1E1KiRC9J/u7lJKK+gqKHEV4pIcRUSOO2D4pJekl6UQER5BoT8QgDDhcDqwma4+5Jl7pZXn2clLCUhgaNfSwZfZX7WdT8SYGhg8kLCiM8KBwwixh7CjbwY95P5JXk0deTR4Ol4OBEQNxeV3MGzCP0rpSAEItoUzuMxmAD3Z/gNVkZXDkYAZHDuanwp+o99QzLWEaEkllfSWVDZUYhZGq+ipSwlKIs8UhhEBKSWZlJrk1uSTaExkQPgCDMODxesityaWvvS9mg/mYrkdZXRl51XlEWaOIt8UDYBAGvNKLV3oBkEjq3HXkVueyLHsZ0dZovNJLVlUW7+96nzhbHClhKaSGp1LnrsPhduD2uhkeNRwhBBajBYfLgRCCi4ddjNVkZUPRBoKMQYyIHkGwKZisyiyCTcHUuGoodZbikR5sJhsh5hCsJiuZlZnE2GIYEjEEL14MGDAbW7bd5XHx5vY3ya3O5dLhl5IakXpM10bTNoSUMjAnFsII7AJOAXKBn4CLpZTbmpW5ERgjpbxeCHERcK6UckFrx01LS5Pr1q1rc308Xg+bijcRbApmYfpCvsn9htTwVIZFDeP0AadjMVowG8xYjBaCjcFYjBayq7LZWrIVr/Ti9rqJs8VhEAb2VuwlNTyV2cmzqWyoJLsqG6/0EmuLpcxZRrApGKvJSrAxGC9eQswhbC3eyri4cTjdTvZU7GFfxT7CgsKobqim1FmKzWzDIAysyF6B3WInJSyFIkcRNpONUEsogyIGEWONYXPxZho8DdR76pFIBoYPJLsqmx/yfqC8vrypvZFBkSSFJnHz+JsxCANFtUUU1Bbw6b5PqWqooqyuDACbyUZYUBiFtYXE2eKYP3g+ZqOZUmcp28u2YzFYSApNIjU8ldSIVFLDU6luqCazMpPv875nZ9lOoq3RxNniGBI5hPK6cuJscThcDoZHDyciKIJ1ResINgZTWldKTUMNYUFhxFpjibXFkmRPorSulG2l28iszKSivgK72U5UcBSjY0Zjt9gBsJvt5NfkU+uuJdwSzjObnmF72XbibHHcMPYGXtn6CtWualLDUxkcMZhgUzDv7niXBm9Di/sgyZ5Ebk0uABFBSmjWuGrIrvJ/deNgYzB1njq/yiXaE3G4HRTUFjRtD7WEMjZ2LOV15WSUZhAZFMnUhKkUOYoodhZjM9korysHAQPCBzAgbAB9QvqQUZpBibOEWGssZqOZEFMINrONYmcxS7OW4vaqpA5GYUQIQURQBNUN1dR76o9a19nJs6lx1VDTUENuTS42kw2ryYrb62Z/9f6mcsK3zE5KWAoOt4MDjgOAElChllAq6yv9uoZmgxmBwGgwEmwMJtoajc1sI8gYREV9BbvLdzdd5+FRw5mROIO+9r58svcT7ky7k2FRw5qETVZlFt/lfkeoJRSTwYTT7cQjPYyJGYPL66K6oRqJJMgYRJAxiGJnMW6vmzGxYwgyBgFQWFtIVlUWDpcDp9uJyWBqKm82mnG4HNQ01BBqCSUiKIKxcWPJrc6lxlUDEpweJw2eBibETSA+JJ7d5bvZU7EHi8GC0WCkzl3HtL7TkFJSVl/GttJtlDhKmJ0ym7e2v8XOsp0EmYIINgYTY43h2tHXEh8S3+KaOVwOip3FpISl+HWND0UIsV5KmXbUcgEUGtOAv0gp5/i+3w0gpfxnszJLfWVWCSFMQCEQK1updHuFRlldGSf89wR1XgRnpJ5BsbOYjJIMql3VR28PAomqlsVg+VlndCzYzXbq3HW4pZtR0aMwGAzsr9pPclgyde46KusrKXIUARBqDsVmtmExWmjwNFDkKCIyKJIZiTMYET2CPiF9yK/JZ2vJVtYUrKGivqLFuYZHDSchJIG0PmnYTDZ2le+ixlVDX3tfNhZtZE3hGgCsJiup4akIBDk1OYftDIKNwUyIn0BFfQV5NXlH7TAEarTavBNrfl3tZjvR1mhqXbWU15XjkZ4jHYo+IX1YMHQBT298Go/0MDJ6JMOjh7OvYh+7K3ZT3VDNqSmncsXIKzjgPEBNQw2FtYVsLVHCe/7g+UQERwBqZFvsLGZn2U6cbiejY0YDkFOdQ3ppOvWeemb0nUGMNYbd5bv5KucrooOjmZk0kw1FGwg2BTfNYtxeN3aznayqLHJrcsmrzsNitDCpzySGRA4hqyqLTQc2saVkC1JK5qXOY33RejIrM0kISSDWGovD7SAqOAqP9JBZmUlmZSY1rhqigqPoF9qPyvpKXF4XTreTWlctIeYQTkk5heMSj1Mzjpo8XF4X+6v2Ex0cTYI9oem6WQwWIoIjmJk4E4HAZDBhNpqbOs/D4XQ7MQkTLq8Lq8nKqoJVPL7+cawmK9eMvgaArSVbya/JJy0+jdK6UuxmO0Mih2A0GCl1luJwOyhzlpESlkKdp46Mkgw80oNHeqj31FPqLKXOXUeDtwGX18X87el+MwAAH1pJREFUwfOZmTSTRbsWsTJ/JZuLN+ORnhb3S7AxGJvZ1jQA6kqsJitOt/Nn24OMQYSYQ9pUJ6MwMjpmNG6vmzpPHTnVOXilF5vZRr27nmhrNPG2ePZX7yfGGsN7Z7zXLo1ATxAa84HTpJTX+L5fhlpS9uZmZdJ9ZXJ93/f6ypQccqzrgOsAkpOTJ2Zn+z8qbKTeU8+Gog04XA5SI1IZED4AUNL7m5xvCLWE4pVe6j31Ta8gYxDT+07HZDBhM9socZTgdDvpH96fjQc2kl6STnhQOP3D+jepJ1LCUqh311PnqcPpdiKRlDhKSLQnsrN8JwkhCQyKHMSAsAFUNVQRZgnDZrYhpcTldWExWg5b/8LaQvZX7Wdi/ESMhoOB/E63k2Bj8GFvopqGGjYVbyLIGES8LZ44WxzBpuBWr1Ops5QQc0iLclJKyurK2Fe5j8zKTEItoQwIH0BKWApWkxUAl9dFZmUmYZYwyuvKiQ+JZ0fpDvJr85nRdwZOj6pnX3tf6tx15NfmU+woZnXBamKtsZza/1Sig6Ob2lHvqSe9JB23141AUFFfQYw1hhBzCJmVmczqN4tgUzD7KveRW53L1ISpTddOSonD7SDEHNKGO6T70tgem8nWY9SHHU11Q3XTrHZ59nK80qtmRq4aEu2JzB0wF4nE7XVjM9lo8DaQUZKBzWzDbrZjEAbqPfU0eBoIMYdgEAb2VOzB5XEhhCDMEsbQqKHYzXaCTcF4vJ6m8vWeemxmpWKrcdWQX5PPExueYEqfKcxMmgkoAeaRHj7e+zH1nnqGRQ0jLT4Nj/Tg8rqoddWy4cAGQs2hhJhDGBkzkmJHMUv2LuHq0VczJHJIU1tzqnJ4Z+c7OFzqHi5xlnDAcQCrycp1Y65jXNy4dl3DniA0LgDmHCI0Jkspb2lWJsNXprnQmCylLD3Scds709BoNJpfMv4KjUB6T+UC/Zp9TwLyj1TGp54KB7p+rqnRaDQaILBC4ydgsBBigBDCAlwELDmkzBLgct/n+cBXrdkzNBqNRtO5BMzlVkrpFkLcDCxFudy+KqXMEEI8AKyTUi4BXgHeFELsQc0wLgpUfTUajUYT4DgNKeVnwGeHbPtzs891wAVdXS+NRqPRHB4dEa7RaDQav9FCQ6PRaDR+o4WGRqPRaPxGCw2NRqPR+I0WGhqNRqPxGy00NBqNRuM3WmhoNBqNxm+00NBoNBqN32ihodFoNBq/0UJDo9FoNH6jhYZGo9Fo/EYLDY1Go9H4jRYaGo1Go/EbLTQ0Go1G4zdaaGg0Go3Gb7TQ0Gg0Go3faKGh0Wg0Gr/RQkOj0Wg0fqOFhkaj0Wj8RgsNjUaj0fiNFhoajUaj8ZuACA0hRJQQYpkQYrfvPfIwZcYJIVYJITKEEFuEEAsCUVeNRqPRHCRQM427gBVSysHACt/3Q3EAv5ZSjgROA54QQkR0YR01Go1GcwimAJ33bGCW7/NC4Bvgj80LSCl3NfucL4Q4AMQCFV1TxU7C64Ut/4Wc1VCUAVED4awnwRQU6JppNBrNUQmU0IiXUhYASCkLhBBxrRUWQkwGLMDeI/x+HXAdQHJycgdX1U88Lsj6AbZ9BNUFMOlaGHyy+s1VB5//Hkr2QMIYWPM8BEdA7FDY8i4IA5z7XGDqrdFoNG2g04SGEGI50OcwP93TxuMkAG8Cl0spvYcrI6V8EXgRIC0tTbaxqseG1wsr7ocNC8FZDuYQsEbCOwtgyvVQtg/2fQuuWgiJg/0rIeU4uOITEAK+/gd8+xCExMAJf4Cg0C6tvqaHc2AHrH0R9q+Ci96CqNRA16j7krcBtn0I5dngKIUz/w3RAwNdqx6HkLJr+1gAIcROYJZvlpEAfCOlHHqYcmEo1dU/pZT/8+fYaWlpct26dR1a31ZZ/hf44XEYcTaMvhAGzQaXE14+Gcr2QngyDDkVRpwD/abAjk8gZTqE+uSp1wMf3Qyb34bgcOgzBmIGQ8wQGHiSmo1oNI14vepe2fo/KN0HlfvBGKRmq3HDYfJ1MPIcMFsDXdPuRWUePDsNXA6ITIGqAkicABe+AbaoQNeuWyCEWC+lTDtquQAJjUeAUinlg0KIu4AoKeUfDiljAT4HPpZSPuHvsbtUaLgb4NFBkDpL3XyH/lZfrW5IIY5+rLz18NOrULwDSndDXaXafsJdMOsu/46h6f389Ap8ejtEDoDEiRA/AiZcDnuWw6d3QEONUn2OOl8NZFJmgDFQWuhuQFU+LLoGCraA1w03/KhmF+sXwse/BZMVZt6uZvm/cLq70IgG3gOSgf3ABVLKMiFEGnC9lPIaIcSlwGtARrNdr5BSbmrt2F0qNHZ9CW9fABf/F4ae1nHHlVLZRVY8AJvfUWquk/6vd6quSvfCuldh/GUQNyzQten+vHA8SC/85vufDySkhOwflWDZ9YVvVN0frvoSQuMDUt2As+IB+P5fMGYBTLtZ2RQbKdyqVMPbP4ah8wCpnrFT/vqLvF7dWmh0Jl0qNBZfDzs/gzv3gMnS8cf3emHp3T7DeTikXQXTf9u7ptOf3wVrngMEDJgJoQlgNENNMeRvVGq6Mx6H2CEH9yneBV/9FbK+V53BrLvB2su9sQvT4Zt/KvXm6Y/AlOtaL9/ggF2fw4c3QZ9RMP81iOjXNXXtLtRXw1NpkDAWLnnv8GU8LvjgOijcolR6JXsgrC9cu0LZJn9BaKHR2bjq4NHBMPwsOOeZzj1X7jpY+RRsX6I60cs/AXts556zq3huBphtSmDs/Uo5E3hcygU5eZoSytGD4fKPYd/XUFcFX96j1H/9Z8DOz5UQnfuIUsn0Rr57VAnJoDCYeiMcf6cSrP6w7SP48EbVcV75WefWszvRUAtvXQD7V8PlS6D/cf7tl70SFp4FQ0+HBW92bh27Gf4KjV+wsvMY8Hrh+0ehvgpGndv550tKgwsXQub36kF442y4+B1l0OvJ1JZAUTrM/jPMvEO9H8qaF5W78sOpygOtkSs+VR1BwWaly3//amUQHn5G19W/s6kqgFVPq9fgOXDeC20f/Y44G0r3KDVNeZZSV/V2XE5452LlUXb+y/4LDFBOKrP+CF/9TXk9pp7QefXsoejcU22lKh/ePBu+841sB8zqunMPmAm/ehcqstUIffvHUJYJ9TVdV4eOQkpY+if1edApRy43/lL1++jz4ZL3IWGccllOmaF+TxirZiHxI9VovLfMnKVUhtpVT6vvJ/6p/eqS0Reo96//Cauehf+cD6/Ngz0rOqau3Y3Pfg+Z38HZz7Zv9jntZohIhncuUnZLTQu0espfag7AprfgxyfBXQenP6w6tEB4NVXshzfPU15WAMIIZz8D4y7u+rq0l28fhq//Dif+H5zwe//383qVF8yhNqSN/4GPboIrv4CUaR1b10CQvRJeOx2GnaG88yZfe2zHW3Yf/OhzQowZolSA1YVw7VfKA6u3kL8JXpwF02+GU//W/uNU5cPbC1RMx2++AVu0Uol2tVrYUabq0mdUp59K2zQ6Eo8bXp4NBZug73g47yUVSxFI6qrU9Lu2RHkfle6GX72nYkG6u3tu+iJ4/yoYcxGc+3zH1LehFh4fBWGJajYWnnTsxwwk71+l3Ghv3wEW27EfT0plGwuNV6Po6iJ4dqqyG1389rEfv7vw8a2w5X9wx3blPHIslGcrb7XwfuB2KjXfjath3WvKKaWzvf0cZfDKqerZHn6m8jAcOLvTXKj9FRpaPXU0PC5Y/BslMOa/Ctd9E3iBARAcBkPmwPhLVMdrssKrc2DhmUqn213xeuHLP0PfCSrnVkcJOEsInHwfFG2Fx0fCJ79TghWgtlSNtD++DTa8CSW7O1+Nlf6Bculs176LlAF73CUdIzBAXed+k5TAACU8xl+qXHOrCzvmHIHG64Edn6rn4lgFBiib4XkvqXuqdI/a9uxUWPsCvD4PirYd+zla46dX1HknXglZP8LbF8Jjw+CbBwOqhtVC42isegbS34eT7u2+3jkxg+GW9cq/PMtnLN/5uRp9r1+oItYbb7KctfDJ7comU1vS9XXNWwdVuTDlNx2fpHHC5XDZYphygxoNPjtNPWzvXaa8z9I/gCU3w9Np8K9hyojeGVTmwvtXwvPHKcHRlgd8zQvKqJ80WQV1diYTLgfpUWrXno7XqxwiaothxFkdd9whp8IpD0C/qXDpIpXhYdrNYDDBwjNUNodVz3ROJ571nVJLnfkE3LETLnob4kcp1+uCVsPVOhWtnmqNskz14Pf3GaB7Aj+9rEYitcXK1iE9avvk65QtZsMbYLGryGGAkefCnH+qtCadqdZyOdW5d3wC2avg93s6N7Yi5ydYdLXSB3tdcO4LKs1L6W7lhrnifohIUfmawvp27Lm/eVA92I3Y41X0duJEpWI4UuDYxrfgoxtVoNn8V7omFchr85QQv2UjGLrZGPLbh9XAZtZdR49NyvxedeITr4R5/wKDsXPrVroXXj8DqvPV96k3wql/77hr6K6HB5OVGuy0ZvdSdSH8a6gSZDNu7Zhz+dAut8eKx6U6HYMR5j4c6Nr4z6Rr1Ahy11LlQTJsLuz8QgXQCaMaJc26WyVS3PqeGoFnLPbFSpwAF7wO5uCOr9eaF2D5fSpH0ukPd34wXr9JcM5z8PpcGHSyCgIUQuXyih2qHBu+/hs8OQF+v7tjo+13L1O2ggVvQcYHypaQt07FnOxZDld+flBAS3nw8+Z3IHaYSknTVak/0q5U9/mT42DMharTDU/smnO3RkWOcpQAJegv/aD1QU3jPTzn750vMEClIvnNd8rtfu2LsPpZcFbA2U8f2/mlVM/tyqfUIO9Qd+HQPhAzVJXpYKHhL1poHImv/qbyQV34xkE9cE/BaFbxCo0xC6mzYPApakQdN1xtSxijXiPOUZHXB7Ypg/qjQ2D2vS29dXZ8qrxHkqe2vS5SKpXY6ufUFP+yD5T9oSvoP0MFQvYZ9fMOZ/otUJmjshPv+0YZGjuK8iwYNg9CotV1bLyWa1+Cz+6E+yPUjKMyF3J/gqFzVdR7zhqltuvKXFGjzlf/0ea3VbqNTW/Ddd8GPnj0p5fVAGPazbDySRXgGDNI2RFSpqlkno24nCp77eBTu+7eAnWN7LFw2oNgjYJv/qG8+s54ov2z9kXXKHW4LRpm/QmGnP7zMgNPhPWvK5tdcNgxNaE9aKFxOPZ9o9wTJ16pgqN6A4NmH357Upp6gVKjrHpGdWymYJhwmfLgePdX6vdrv1aZQRvxuFT54WcePsV09krlM1+UrqKZT3mgax9qULEth8McrNQYGYvVSLFom0oSedxtYG91eZfWaagFR8nhBxoTfq3Sc9ceUJ1z3HA1ktz6nso15mlo2Rl2BULAmAvUK38jvDJHjfDP9DtHaMdTXaj+k5Hnwsl/UbPir5u5z4b2hdu2HhSuG95Uqc4nXROI2qprOOuPambww2PqOTrxT20/zt6vlcCYepMKdD3SjH/0BSq10LYP1T3VxWihcThWPwdhSTDnH4GuSdcy6y447nfKP33JzUpw2mIO/r74NypRnrsO/nsplOyCmiKldpp2sxKyMYNU3qOidOXBVF+j1i0YNR+C7IFr2+EwmlW6iC3/VdN9UOuazLy9/ces2K/eDxd5bQo6uNiW16PUGFLCkltg45vKo6wxaDEQ9B2vjMjbPlRpWfxNVdJePC6lsqvIUUk5G4XAN/9Uv510r7pG819VAzl7vBIg71+p8moNP1PFTvz4bzWLbUvkd2cw+89qQPDtQ2rQMP5S//dtTBVj7wMn3dO6ijhxooq12fKeFhrdAled6kA60t2xJ2EKgl/9V6kHsn5UKpPUE5U65z/nqQjlXUshd+3BfYafqUY+q55WcSIlu1QOKYAzn4SJlwemLf5w1lMqg7A9XgWFZX7XMULjaCrNRr23EEo1NfAkpV4J9LK/I89Ta3VkfqtsQZ3F94+pwVntAfV9/esqPXnCWOUwMfk3EDVA/WYKUm60oLyHbNHKO3D4mUrgV+WqmVGg45OEgDP+rZJLrn3pyELD41a2kEbjfvYqJTBGngunPXT02bgQ6l5Z+5IymHfxPaOFxqFk/6hSSg9uJbVFb8cUBNNuUq/mhtrENHVzN0agf/sQTLtFZVytLlKj5fRFarRsj1fL33ZXN+VGTEEHO/gBxyvh9/YC5d7YHoNmebZ6j2hDXjCjGUad1/ZzdQaDZitVYvrizhMa2SuV91rqiTD1GaWaW3avSqzYd7zy7jv+CFkCjCY10s7fqDrfHx5TgqYzBVxbMJpUXX54XM2ym8+uvR41e9/0tloU6qbVyhby1V/V83L2s/4PVJOnqUFa3oYuz4CghcahrHle5fjpfwRd+C+N5qO3GbeqSOVznlWeNs1HUqHxKvvq8Xd2fR07imFnqP9/1xdQlNFy7QV/qC2FnZ8qe9Cx2EUCiSlIGfF3fAzux48t5b/XozpPo0XNNoPDVRqeZfcqtedFbx/sJJPS4LnpagY7+z7lRHAk+o5XXmg/vazUVRe+GfhZRnOSpypX97x1kDRJLckbM1jN0Fc8oNL/u53KfuQoUWlx5j7aNs1Gsk9Q7F+phUZAKdgMu79UN+0vUTV1NEacBXfn9N6lRAfMhN9uhCfHq9Gwv0JDSlj3iuoQ6muUTro7dWJtZdR85f676GqlbgwKVeqQsIS2HWfpPb61UlDBpOMugfWvqZnqGY+1fMbiR8Ili1Rn21oCS1C2H+mFL/6oZrXDullm46RJyvNrxV+Va3flfkAogRw7DG5YBaufUbPycRerDMZt9UwMiYboQWqm0cVoodGcHZ8BQsU5aA5PbxUYjUSlKnXV3q+U++uROn93vQqgDE9SarlP71BxLqc/3PNXIBw0Wy0z/N0jag0XUB35pe/7f4yK/fDTS+pZSrtSGasbBUhjWvtDGeyniqnfZGUwjhsG573c/YISrRHK7XbZvWotmJPuUcb+oq3KWcRgUDbC6bcc23n6jNZCI+DsWa70pa1NjTW9n6HzVAf33HTlTTbyvIOePWX7lKF2wxvK2D/qfJUnasAJKoVJVwSWdTZCwIl3K8N0Q41SKX3/KBTvVIGR/vDjk4BQxwhPUkGjQ+cpx4pj9RCzRcGdO4/tGJ3NxMs73wGkz2jlMl5X2TG5tvykm4noAFJbqoL5fskGcI3i1L+qtCPSCx9cC09NUCk+Ft+gVFc//lvplGOGKE+jxIlqkazeIDCaYzCqzmjqDcousf51//bL26CE6tiLWmYbHnMBzHu0Z6vuuhPxo9V7UUaXnlbPNBoxmpWeNSXAvt6awGM0qw5v9IUqHuC7R1VOKICxF8OJ96j1tmtLoSILEsZ3PxVJRxISA0NOUwLylL+2HrGesRj+dwVYQtUsTdN59PEJjf2r1IqDXUQvvtPbSHCYSg4WOyTQNdF0FwwG5Ul0xacHt83+sxIYoNSYiRN7t8BoZOxFyoaz96sjlynPhiW3KtfsWzcfPkuApuMIS1Bu4mtfVkGOXURA7nYhRJQQYpkQYrfv/YjrWAohwoQQeUKIp7uyjhpNExYb/PojFYTX0RlxewqDTlExBZvfVhH/Xm/L3xsTfILK0Kvtgl3DjNtUpt2t73XZKQOlnroLWCGlfFAIcZfv+x+PUPavwLddVjON5nCkzlKvXyomC4yer3JCZSxW24wWFdN02Yeq08r9SRm8D5dCRdM5DDxJqal+/DeM/VWXzHoDJTTOBmb5Pi8EvuEwQkMIMRGIB74AjprnXaPRdCIzblUu18ERKrmiywGrnoVPb1drlEy8QqXC0HQdQqjZxqKrVVDqsLmdf8pALMIkhKiQUkY0+14upYw8pIwB+Aq4DJgNpEkpbz7C8a4DrgNITk6emJ2d3Wl112g0zXh7geqsYofDtV/poNhA4HHDU+NV9t+rl7b7MAFfI1wIsVwIkX6Yl7+5xm8EPpNS5hytoJTyRSllmpQyLTY2wOsAaDS/JCZcrmwd81/VAiNQGE1KNZWzRqXm72Q6TT0lpTxieKcQokgIkSClLBBCJAAHDlNsGjBTCHEjYAcsQogaKWUnL5ys0Wj8ZthcGLpPx14Emj6jAKkCMJuvedMJBMpXcAnQGC55OfDRoQWklJdIKZOllP2BO4E3tMDQaLohWmAEnljfipwHtnf6qQIlNB4EThFC7AZO8X1HCJEmhHg5QHXSaDSanknUADAGqWWbO5mAeE9JKUtRxu1Dt68DfrZmo5TydeD1Tq+YRqPR9EQMRpUXrAtmGjqNiEaj0fQGRpwFLmenn0YLDY1Go+kNHGm1ww7mF5A0R6PRaDQdhRYaGo1Go/EbLTQ0Go1G4zdaaGg0Go3Gb7TQ0Gg0Go3faKGh0Wg0Gr/RQkOj0Wg0fqOFhkaj0Wj8JiDraXQmQohiwN8FNWKAkk6sTlei29I96U1tgd7VHt2WlqRIKY+6tkSvExptQQixzp9FR3oCui3dk97UFuhd7dFtaR9aPaXRaDQav9FCQ6PRaDR+80sXGi8GugIdiG5L96Q3tQV6V3t0W9rBL9qmodFoNJq28UufaWg0Go2mDWihodFoNBq/6XFCQwjRTwjxtRBiuxAiQwhxq297lBBimRBit+890rddCCGeFELsEUJsEUJMOOR4YUKIPCHE062c827f/juFEHOabX9VCHFACJHeU9shhAgWQqwVQmz21eP+ntoW3/YsIcRWIcQmIcS6ntoWIcRQXxsaX1VCiNt6ant8228VQqT76tHt2yKEiPadr+bQMkKIvwshcoQQNW1tR0e3RQjhaXafLGnlnJf7jrtbCHF5u9sipexRLyABmOD7HArsAkYADwN3+bbfBTzk+zwX+BwQwFRgzSHH+zfwNvD0Ec43AtgMBAEDgL2A0ffb8cAEIL2ntsN3PLuvjBlYA0ztiW3x/ZYFxPSG+6tZGSNQiAq+6pHtAUYB6YANtWLocmBwN29LCHAccP2hZXzHSwBqAn2f+VMHIArY53uP9H2ObE9betxMQ0pZIKXc4PtcDWwHEoGzgYW+YguBc3yfzwbekIrVQIQQIgFACDERiAe+bOWUZwPvSinrpZSZwB5gsu/83wFlPbkdvuM1jjDMvlebvCO6S1vaUuce1pbZwF4ppb+ZDrpje4YDq6WUDimlG/gWOLc7t0VKWSul/AGoO8xvq6WUBW2pf2e1xU/mAMuklGVSynJgGXBae9rS44RGc4QQ/YHxqNFxfGPDfe9xvmKJQE6z3XKBRCGEAfgXcLSFdQ+7/7HWvTmBbocQwiiE2AQcQN1Ya3pqW1AC70shxHohxHXtbQd0i7Y0chHwTttb0JIAtycdON6n8rGhRs79unlbuoRjaYvvc7AQYp0QYrUQ4hwOT4f1Y6b27NQdEELYgUXAbVLKKiHEEYseZpsEbgQ+k1LmtLJva/t3CN2hHVJKDzBOCBEBLBZCjJJStsdOE/C2ADOklPlCiDhgmRBih29G2Ca6SVsQQliAs4C7/an3EU8S4PZIKbcLIR5CjXBrUCost7/1b3GCrmtLp9MBbQFI9t3zqcBXQoitUsq9bdi/TfRIoSGEMKMu9FtSyg98m4uEEAlSygLftO2Ab3suLUc0SUA+MA2YKYS4EbADFp8haA1wn6/sNa3s3+vaIaWsEEJ8g5q2tklodJe2SCkb3w8IIRajVCNtEhrdpS0+Tgc2SCmL2tKG7tgeKeUrwCu+Ov3DV7bbtkVK2WZHigC0pfk9v8/3/I4XQsQAL/jK/tm3/6xD9v+mXRWX7TQYBuqFkphvAE8csv0RWhqQHvZ9nkdLA9LawxzzCo5sDBtJS8PePpoZKoH+tM8Q3i3aAcQCEb4yVuB74Iwe2pYQINRXJgRYCZzWE9vS7Pd3gSt7w/MCxPnek4Ed+Ayx3bUtfra3vYbwDmkLyqgd5PscA+wGRhzmfFFApq98pO9zVHva0q4bMZAvlDeDBLYAm3yvuUA0sMJ30VY0XhDfRX4G5cWxFUhr640D3OPbfydwerPt7wAFgAslya/uae0AxgAbffVIB/7cU/8TIBXVYW0GMoB7empbfNttQCkQ3kuel++Bbb7/Z3YPaUsWytmlBvWMj/Btf9j33et7/0sg2gJM933f7Hs/Yh8EXIVyTNhDs4FIW9ui04hoNBqNxm96tPeURqPRaLoWLTQ0Go1G4zdaaGg0Go3Gb7TQ0Gg0Go3faKGh0Wg0Gr/RQkOjOUaaZRnNECpb8O2+VBWt7dNfCPGrrqqjRtNRaKGh0Rw7TinlOCnlSOAUlL/9fUfZpz+ghYamx6HjNDSaY0QIUSOltDf7ngr8hIrQTQHeREWoA9wspVwphFiNyvyaicpm+iTwICrVQxDwjJTyBTSaboYWGhrNMXKo0PBtKweGAdWAV0pZJ4QYDLwjpUwTQswC7pRSnuErfx0qzcbfhBBBwI/ABVKlF9doug09MmGhRtMDaMwqagaeFkKMAzzAkCOUPxUYI4SY7/seDgxGzUQ0mm6DFhoaTQfjU095UBlK7wOKgLEoG+LPFvRp3A24RUq5tEsqqdG0E20I12g6ECFELPA8KgmeRM0YCqSUXuAyVDZeUGqr0Ga7LgVu8KXLRggxRAgRgkbTzdAzDY3m2LH6Vj40oxYWehN4zPfbs8AiIcQFwNdArW/7FsAthNgMvI5ar7o/sEGolXiKObjUp0bTbdCGcI1Go9H4jVZPaTQajcZvtNDQaDQajd9ooaHRaDQav9FCQ6PRaDR+o4WGRqPRaPxGCw2NRqPR+I0WGhqNRqPxm/8HNHa3O/GjesoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fbeca2a0eb8>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pchar = build_portfolio_characteristics()\n",
+    "\n",
+    "for column in pchar.columns:\n",
+    "        plt.plot(pchar[column], label=column)\n",
+    "plt.legend(loc='upper left')\n",
+    "plt.xlabel('Date')\n",
+    "plt.ylabel('Portfolio')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Optional\n",
+    "Choose additional metrics to evaluate your portfolio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Submission\n",
+    "Now that you're done with the project, it's time to submit it. Click the submit button in the bottom right. One of our reviewers will give you feedback on your project with a pass or not passed grade."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/02 - AI Algorithms in Trading/Project 08 - Backtesting/Project 08 - Backtesting/requirements.txt
+++ b/02 - AI Algorithms in Trading/Project 08 - Backtesting/Project 08 - Backtesting/requirements.txt
@@ -1,0 +1,7 @@
+matplotlib==2.1.0
+numpy==1.16.1
+pandas==0.24.1
+patsy==0.5.1
+scipy==0.19.1
+statsmodels==0.9.0
+tqdm==4.19.5


### PR DESCRIPTION
Add Jupyter notebook to build a fairly realistic backtester that uses the Barra data.
The backtester performs portfolio optimization that includes transaction costs,
and it is implemented with computational efficiency in mind, to allow for a
reasonably fast backtest. Performance attribution is used to identify the
major drivers of the portfolio's profit-and-loss (PnL).